### PR TITLE
ISSUE #11 のコミット漏れを回収

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -209,5 +209,5 @@ packages:
     source: hosted
     version: "14.3.0"
 sdks:
-  dart: ">=3.6.0-334.4.beta <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  dart: ">=3.6.0 <4.0.0"
+  flutter: ">=3.27.1"


### PR DESCRIPTION
- ISSUE #11: fvm で Flutter バージョンを最新 3.27.1 に更新
- pubspec.lock: Flutter /Dart 最新バージョン指定

# プルリクエスト説明
## 目的
ISSUE #11 (fvm で Flutter バージョンを最新 3.27.1 に更新) でコミット漏れしていた、
pubspec.lock の Flutter/Dart 最新バージョン指定をリポジトリに回収します。

## 対応 ISSUE
- ISSUE #11

## 対応内容
pubspec.lock の Flutter/Dart 最新バージョン指定をリポジトリに回収。

## 妥協点

## テスト

## 補足
