### PR TITLE
light/dark Theme に対応

### DIFF
--- a/lib/application/app_widget/app_widget.dart
+++ b/lib/application/app_widget/app_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:search_repositories_on_github/application/theme/theme.dart';
 import 'package:search_repositories_on_github/presentation/home_page/page_widget/home_page_widget.dart';
 
 class MyApp extends StatelessWidget {
@@ -8,10 +9,8 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Flutter Demo',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-        useMaterial3: true,
-      ),
+      theme: createThemeData(context),
+      darkTheme: createDarkThemeData(context),
       home: const MyHomePage(title: 'Flutter Demo Home Page'),
     );
   }

--- a/lib/application/theme/theme.dart
+++ b/lib/application/theme/theme.dart
@@ -31,6 +31,11 @@ ColorScheme _createColorScheme({required bool isDark}) {
 TextTheme _createTextTheme(BuildContext context, ColorScheme colorScheme) {
   final ThemeData baseThemeData = Theme.of(context);
   final TextTheme baseTextTheme = baseThemeData.textTheme;
+  /*
+  // FIXME 将来的に Google Fonts 対応する場合
+  TextTheme textTheme =
+      GoogleFonts.notoSansJpTextTheme(baseThemeData.textTheme);
+  */
   return TextTheme(
     displayLarge: _convertColor(baseTextTheme.displayLarge, colorScheme),
     displayMedium: _convertColor(baseTextTheme.displayMedium, colorScheme),

--- a/lib/application/theme/theme.dart
+++ b/lib/application/theme/theme.dart
@@ -2,16 +2,20 @@ import 'package:flutter/material.dart';
 
 ThemeData createThemeData(BuildContext context) {
   final ColorScheme colorScheme = _createColorScheme(isDark: false);
+  final TextTheme textTheme = _createTextTheme(context);
   return ThemeData.from(
     colorScheme: colorScheme,
+    textTheme: textTheme,
     useMaterial3: true,
   );
 }
 
 ThemeData createDarkThemeData(BuildContext context) {
   final ColorScheme colorScheme = _createColorScheme(isDark: true);
+  final TextTheme textTheme = _createTextTheme(context);
   return ThemeData.from(
     colorScheme: colorScheme,
+    textTheme: textTheme,
     useMaterial3: true,
   );
 }
@@ -22,6 +26,14 @@ ColorScheme _createColorScheme({required bool isDark}) {
     seedColor: _seedColor,
   );
   return colorScheme;
+}
+
+TextTheme _createTextTheme(BuildContext context) {
+  final ThemeData baseThemeData = Theme.of(context);
+  final TextTheme baseTextTheme = baseThemeData.textTheme;
+  return TextTheme(
+    displayMedium: baseTextTheme.displayMedium,
+  );
 }
 
 const Color _seedColor = Color(0xFF2979FF);

--- a/lib/application/theme/theme.dart
+++ b/lib/application/theme/theme.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 
 ThemeData createThemeData(BuildContext context) {
   final ColorScheme colorScheme = _createColorScheme(isDark: false);
-  final TextTheme textTheme = _createTextTheme(context);
+  final TextTheme textTheme = _createTextTheme(context, colorScheme);
   return ThemeData.from(
     colorScheme: colorScheme,
     textTheme: textTheme,
@@ -12,7 +12,7 @@ ThemeData createThemeData(BuildContext context) {
 
 ThemeData createDarkThemeData(BuildContext context) {
   final ColorScheme colorScheme = _createColorScheme(isDark: true);
-  final TextTheme textTheme = _createTextTheme(context);
+  final TextTheme textTheme = _createTextTheme(context, colorScheme);
   return ThemeData.from(
     colorScheme: colorScheme,
     textTheme: textTheme,
@@ -28,12 +28,21 @@ ColorScheme _createColorScheme({required bool isDark}) {
   return colorScheme;
 }
 
-TextTheme _createTextTheme(BuildContext context) {
+TextTheme _createTextTheme(BuildContext context, ColorScheme colorScheme) {
   final ThemeData baseThemeData = Theme.of(context);
   final TextTheme baseTextTheme = baseThemeData.textTheme;
   return TextTheme(
-    displayMedium: baseTextTheme.displayMedium,
+    displayMedium: _convertColor(baseTextTheme.displayMedium, colorScheme),
   );
+}
+
+// ダークテーマ対応
+TextStyle? _convertColor(TextStyle? textStyle, ColorScheme colorScheme) {
+  if (textStyle == null) {
+    return null;
+  }
+  final Color color = colorScheme.onSurface;
+  return textStyle.copyWith(color: color);
 }
 
 const Color _seedColor = Color(0xFF2979FF);

--- a/lib/application/theme/theme.dart
+++ b/lib/application/theme/theme.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+ThemeData createThemeData(BuildContext context) {
+  final ColorScheme colorScheme = _createColorScheme(isDark: false);
+  return ThemeData.from(
+    colorScheme: colorScheme,
+    useMaterial3: true,
+  );
+}
+
+ThemeData createDarkThemeData(BuildContext context) {
+  final ColorScheme colorScheme = _createColorScheme(isDark: true);
+  return ThemeData.from(
+    colorScheme: colorScheme,
+    useMaterial3: true,
+  );
+}
+
+ColorScheme _createColorScheme({required bool isDark}) {
+  final ColorScheme colorScheme = ColorScheme.fromSeed(
+    brightness: isDark ? Brightness.dark : Brightness.light,
+    seedColor: _seedColor,
+  );
+  return colorScheme;
+}
+
+const Color _seedColor = Color(0xFF2979FF);

--- a/lib/application/theme/theme.dart
+++ b/lib/application/theme/theme.dart
@@ -32,7 +32,21 @@ TextTheme _createTextTheme(BuildContext context, ColorScheme colorScheme) {
   final ThemeData baseThemeData = Theme.of(context);
   final TextTheme baseTextTheme = baseThemeData.textTheme;
   return TextTheme(
+    displayLarge: _convertColor(baseTextTheme.displayLarge, colorScheme),
     displayMedium: _convertColor(baseTextTheme.displayMedium, colorScheme),
+    displaySmall: _convertColor(baseTextTheme.displaySmall, colorScheme),
+    headlineLarge: _convertColor(baseTextTheme.headlineLarge, colorScheme),
+    headlineMedium: _convertColor(baseTextTheme.headlineMedium, colorScheme),
+    headlineSmall: _convertColor(baseTextTheme.headlineSmall, colorScheme),
+    titleLarge: _convertColor(baseTextTheme.titleLarge, colorScheme),
+    titleMedium: _convertColor(baseTextTheme.titleMedium, colorScheme),
+    titleSmall: _convertColor(baseTextTheme.titleSmall, colorScheme),
+    bodyLarge: _convertColor(baseTextTheme.bodyLarge, colorScheme),
+    bodyMedium: _convertColor(baseTextTheme.bodyMedium, colorScheme),
+    bodySmall: _convertColor(baseTextTheme.bodySmall, colorScheme),
+    labelLarge: _convertColor(baseTextTheme.labelLarge, colorScheme),
+    labelMedium: _convertColor(baseTextTheme.labelMedium, colorScheme),
+    labelSmall: _convertColor(baseTextTheme.labelSmall, colorScheme),
   );
 }
 


### PR DESCRIPTION
# プルリクエスト説明
## 目的
light Theme と dark Theme を用意して、MaterialApp プロパティの theme /darkTheme を設定し、
プラットフォームシステムでの Light / Dark モード切り替えに視覚的に対応しました。

## 対応 ISSUE
Close #20

## 対応内容
lMaterialApp プロパティの theme /darkTheme 用の Theme を設定し、
プラットフォームシステムでの Light / Dark モード切り替えに視覚的に対応しました。

## 妥協点
簡易的な対応のため個別ウィジェット用の色設定など凝ったことはしていません。
このためアプリ表示デザイン洗練時には、アプリ独自の Color Scheme パターンの設定や
Google Fonts 対応があれば TextTheme ロジックの改修が必要になります。

## テスト


https://github.com/user-attachments/assets/940abe22-dc4f-49e9-bfee-fb0a45ad55a6



## 補足
<!-- その他補足事項があれば、記載してください。 -->
