### PR TITLE
Lint 警告対応＋一部 Lintルール除外

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -53,7 +53,7 @@ linter:
     - avoid_slow_async_io
     - avoid_type_to_string
     - avoid_types_as_parameter_names
-    - avoid_types_on_closure_parameters
+    ##- avoid_types_on_closure_parameters
     - avoid_unnecessary_containers
     - avoid_unused_constructor_parameters
     - avoid_void_async
@@ -117,7 +117,7 @@ linter:
     - noop_primitive_operations
     - null_check_on_nullable_type_parameter
     - null_closures
-    - omit_local_variable_types
+    ##- omit_local_variable_types
     #- one_member_abstracts
     - only_throw_errors
     - overridden_fields

--- a/lib/presentation/home_page/page_widget/home_page_widget.dart
+++ b/lib/presentation/home_page/page_widget/home_page_widget.dart
@@ -1,12 +1,19 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
+  const MyHomePage({required this.title, super.key});
 
   final String title;
 
   @override
   State<MyHomePage> createState() => _MyHomePageState();
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(StringProperty('title', title));
+  }
 }
 
 class _MyHomePageState extends State<MyHomePage> {


### PR DESCRIPTION
# プルリクエスト説明
## 目的
Lint 警告に対応するため実装の修正を行ました。
今回プロジェクトにおける一部ルールの除外設定を行いました。

## 対応 ISSUE
- #18

## 対応内容
- 公開プロバティ値が開発ツールで確認できるよう、
- analysis_options.yaml に指定した lint ルールの一部を除外します。
  - avoid_types_on_closure_parameters: 型推測による関数式のパラメータを省略しないように除外
  - omit_local_variable_types: final や var で型省略させないように除外

## 妥協点

## テスト

## 補足