### PR TITLE
型省略させないルール方針に修正

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -16,7 +16,7 @@ linter:
     - always_declare_return_types
     - always_put_control_body_on_new_line
     - always_put_required_named_parameters_first
-    #- always_specify_types
+    - always_specify_types
     - always_use_package_imports
     - annotate_overrides
     - annotate_redeclares
@@ -41,7 +41,7 @@ linter:
     - avoid_positional_boolean_parameters
     - avoid_print
     - avoid_private_typedef_functions
-    - avoid_redundant_argument_values
+    ##- avoid_redundant_argument_values
     - avoid_relative_lib_imports
     - avoid_renaming_method_parameters
     - avoid_return_types_on_setters
@@ -191,7 +191,7 @@ linter:
     - unnecessary_constructor_name
     #- unnecessary_final
     - unnecessary_getters_setters
-    - unnecessary_lambdas
+    ##- unnecessary_lambdas
     - unnecessary_late
     - unnecessary_library_directive
     - unnecessary_library_name


### PR DESCRIPTION
- always_specify_types: true
- always_declare_return_types: true
- avoid_redundant_argument_values: false
- avoid_types_on_closure_parameters: false
- omit_local_variable_types: false
- unnecessary_lambdas: false

# プルリクエスト説明
## 目的
- ISSUE #26 参照
プロジェクトでは、型推論による型省略記述を避けるようにして、
コード意図の読解を優先して、冗長なコード記述を受認することにします。


## 対応 ISSUE
Close #26 

## 対応内容
analysis_options.yaml の lint: rules: 
- always_specify_types: true
- always_declare_return_types: true
- avoid_redundant_argument_values: false
- avoid_types_on_closure_parameters: false
- omit_local_variable_types: false
- unnecessary_lambdas: false

## 妥協点
変数宣言での型明記によりコードが冗長になりますが、
コード意図の読解を優先して、冗長なコード記述を受認することにします。
