### PR TITLE
アプリケーションレベルのエラーハンドリング対応を追加

### DIFF
--- a/lib/application/app_widget/app_widget.dart
+++ b/lib/application/app_widget/app_widget.dart
@@ -3,6 +3,18 @@ import 'package:search_repositories_on_github/application/l10n/gen/app_localizat
 import 'package:search_repositories_on_github/application/theme/theme.dart';
 import 'package:search_repositories_on_github/presentation/home_page/page_widget/home_page_widget.dart';
 
+/// グローバルにアクセス可能な Navigator のキー
+///
+GlobalKey<NavigatorState> globalNavigatorKey =
+    GlobalKey<NavigatorState>(debugLabel: 'app');
+
+/// グローバルにアクセス可能な Navigator 稼働中フラグ
+bool get isGlobalNavigatorRunning => globalNavigatorKey.currentState != null;
+
+/// グローバルにアクセスが可能な Navigator の [BuildContext]
+BuildContext get globalNavigatorContext =>
+    globalNavigatorKey.currentState!.context;
+
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
@@ -10,6 +22,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Flutter Demo',
+      navigatorKey: globalNavigatorKey,
       theme: createThemeData(context),
       darkTheme: createDarkThemeData(context),
       localizationsDelegates: AppLocalizations.localizationsDelegates,

--- a/lib/application/error/app_error_dialog.dart
+++ b/lib/application/error/app_error_dialog.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:search_repositories_on_github/application/app_widget/app_widget.dart';
 
 /// アプリレベルのエラーダイアログ表示サービス
 class AppErrorHandlerDialog {
@@ -43,33 +42,47 @@ class AppErrorHandlerDialog {
       );
     }
   }
+
+  void showAppBeforeLaunchErrorAlertDialog({
+    required String title,
+    required String message,
+  }) {
+    // エラー表示専用アプリ起動
+    runApp(
+      _ShowErrorDialogApp(
+        title: title,
+        message: message,
+        errorDialog: this,
+      ),
+    );
+  }
 }
 
 /// アプリレベルのエラーダイアログ表示サービス・ウィジェット
 ///
 /// アプリ未起動時用のエラー表示だけの AppWidget です。
-class ShowErrorDialogApp extends StatelessWidget {
-  const ShowErrorDialogApp({
+class _ShowErrorDialogApp extends StatelessWidget {
+  _ShowErrorDialogApp({
     required this.title,
     required this.message,
-    super.key,
+    required this.errorDialog,
   });
 
   final String title;
   final String message;
+  final AppErrorHandlerDialog errorDialog;
+  final GlobalKey<NavigatorState> globalNavigatorKey =
+      GlobalKey<NavigatorState>(debugLabel: 'app');
 
   Future<void> _showError() async {
-    final AppErrorHandlerDialog errorDialog = AppErrorHandlerDialog();
-    if (isGlobalNavigatorRunning) {
-      final BuildContext context = globalNavigatorContext;
-      if (context.mounted) {
-        await errorDialog.showErrorAlertDialog(
-          context: context,
-          title: title,
-          message: message,
-          isExitApp: true,
-        );
-      }
+    final BuildContext context = globalNavigatorKey.currentState!.context;
+    if (context.mounted) {
+      await errorDialog.showErrorAlertDialog(
+        context: context,
+        title: title,
+        message: message,
+        isExitApp: true,
+      );
     }
   }
 
@@ -87,5 +100,14 @@ class ShowErrorDialogApp extends StatelessWidget {
     super.debugFillProperties(properties);
     properties.add(StringProperty('message', message));
     properties.add(StringProperty('title', title));
+    properties.add(
+      DiagnosticsProperty<AppErrorHandlerDialog>('errorDialog', errorDialog),
+    );
+    properties.add(
+      DiagnosticsProperty<GlobalKey<NavigatorState>>(
+        'globalNavigatorKey',
+        globalNavigatorKey,
+      ),
+    );
   }
 }

--- a/lib/application/error/app_error_dialog.dart
+++ b/lib/application/error/app_error_dialog.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:search_repositories_on_github/application/app_widget/app_widget.dart';
+
+/// アプリレベルのエラーダイアログ表示サービス
+class AppErrorHandlerDialog {
+  Future<void> showErrorAlertDialog({
+    required BuildContext context,
+    required String title,
+    required String message,
+    required bool isExitApp,
+  }) async {
+    if (context.mounted) {
+      await showDialog<void>(
+        context: context,
+        useRootNavigator: true,
+        barrierDismissible: false,
+        builder: (BuildContext context) {
+          // バックボタンでのダイアログ表示クローズを抑止します。
+          return PopScope(
+            canPop: false,
+            child: AlertDialog(
+              title: Text(title),
+              content: SingleChildScrollView(
+                child: Text(message),
+              ),
+              // Apple human interface よりアプリを終了させるのはユーザです。
+              // Androidアプリの SystemNavigator.pop() はプロセス終了でないため
+              // Recent App List に残ったタスクの消去はユーザ操作となります。
+              // このためiOS/Android でのアプリ終了は、ユーザに依頼するのでボタンはありません。
+              actions: <Widget>[
+                if (!isExitApp)
+                  TextButton(
+                    onPressed: () {
+                      Navigator.pop(context);
+                    },
+                    child: const Text('OK'),
+                  ),
+              ],
+            ),
+          );
+        },
+      );
+    }
+  }
+}
+
+/// アプリレベルのエラーダイアログ表示サービス・ウィジェット
+///
+/// アプリ未起動時用のエラー表示だけの AppWidget です。
+class ShowErrorDialogApp extends StatelessWidget {
+  const ShowErrorDialogApp({
+    required this.title,
+    required this.message,
+    super.key,
+  });
+
+  final String title;
+  final String message;
+
+  Future<void> _showError() async {
+    final AppErrorHandlerDialog errorDialog = AppErrorHandlerDialog();
+    if (isGlobalNavigatorRunning) {
+      final BuildContext context = globalNavigatorContext;
+      if (context.mounted) {
+        await errorDialog.showErrorAlertDialog(
+          context: context,
+          title: title,
+          message: message,
+          isExitApp: true,
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    Future<void>.delayed(const Duration(milliseconds: 500), _showError);
+    return MaterialApp(
+      navigatorKey: globalNavigatorKey,
+      home: const Scaffold(),
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(StringProperty('message', message));
+    properties.add(StringProperty('title', title));
+  }
+}

--- a/lib/application/error/app_error_handler.dart
+++ b/lib/application/error/app_error_handler.dart
@@ -18,18 +18,26 @@ class AppErrorHandler {
   /// コンストラクタ
   ///
   /// _シングルトン・インスタンスにするため、_<br/>
-  /// _2回目の生成はエラーとなることに注意ください。_
+  /// _2回目の生成はエラーとすることに注意ください。_
   AppErrorHandler() {
     _instance = this;
   }
 
   /// シングルトン・インスタンス
+  // ignore: unused_field
   static late final AppErrorHandler _instance;
 
-  bool _hasError = false;
+  AppErrorType _errorType = AppErrorType.noError;
+  Object? _error;
 
   /// アプリケーションレベル・エラー発生有無フラグ
-  bool get hasError => _hasError;
+  bool get hasError => _error != null;
+
+  /// アプリケーションレベル・エラー種別
+  AppErrorType get errorType => _errorType;
+
+  /// アプリケーションレベル・エラー
+  Object? get error => _error;
 
   /// アプリ起動
   ///
@@ -71,6 +79,8 @@ class AppErrorHandler {
         // ignore: avoid_catches_without_on_clauses
       } catch (e) {
         debugLog('Error occurred in appInitialize', cause: e);
+        _error = e;
+        _errorType = AppErrorType.appInitializeError;
 
         // トップレベルまで上がってきた未処置の想定外のエラーなので、
         // アプリをユーザーに強制終了してもらうようにします。
@@ -115,7 +125,8 @@ class AppErrorHandler {
     debugLog('StackTraces=\n${details.stack.toString()}');
     debugLog('FlutterError.dumpErrorToConsole');
     FlutterError.dumpErrorToConsole(details, forceReport: true);
-    _hasError = true;
+    _error = error;
+    _errorType = AppErrorType.flutterError;
 
     // オプションのエクセプションハンドラ処置を実行
     if (_optionFlutterExceptionHandler != null) {
@@ -141,7 +152,8 @@ class AppErrorHandler {
   bool _platformErrorHandler(Object error, StackTrace stackTrace) {
     debugLog('PlatformDispatcherErrorHandle', cause: error);
     debugLog('StackTraces=\n${stackTrace.toString()}');
-    _hasError = true;
+    _error = error;
+    _errorType = AppErrorType.platformError;
 
     // オプションのエラーハンドラ処置を実行
     if (_optionPlatformErrorHandler != null) {
@@ -165,7 +177,8 @@ class AppErrorHandler {
   void _asynchronousErrorHandler(Object error, StackTrace stack) {
     debugLog('AsynchronousErrorHandle', cause: error);
     debugLog('StackTraces=\n${stack.toString()}');
-    _hasError = true;
+    _error = error;
+    _errorType = AppErrorType.asynchronousError;
 
     // オプションのエラーハンドラ処置を実行
     if (_optionAsynchronousErrorHandler != null) {
@@ -183,4 +196,13 @@ class AppErrorHandler {
       ),
     );
   }
+}
+
+/// アプリケーションレベル・エラー種別
+enum AppErrorType {
+  appInitializeError,
+  flutterError,
+  platformError,
+  asynchronousError,
+  noError;
 }

--- a/lib/application/error/app_error_handler.dart
+++ b/lib/application/error/app_error_handler.dart
@@ -9,6 +9,8 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:search_repositories_on_github/application/app_widget/app_widget.dart';
 import 'package:search_repositories_on_github/application/error/app_error_dialog.dart';
+import 'package:search_repositories_on_github/application/l10n/gen/app_localizations_ja.dart';
+import 'package:search_repositories_on_github/application/l10n/l10n_service.dart';
 import 'package:search_repositories_on_github/foundation/debug/debug_logger.dart';
 
 /// アプリレベルのエラーハンドラ設定クラス
@@ -70,15 +72,16 @@ class AppErrorHandler {
       } catch (e) {
         debugLog('Error occurred in appInitialize', cause: e);
 
-        // TODO トップレベルまで上がってきた未処置のエラーなので、Crashlytics でログ記録を取ること。
-        // TODO 想定外のエラーなので、アプリをユーザーに強制終了してもらうようにすること。
-        // TODO ただし、アプリが起動していないため l10n リソースもロケールも使えません。
+        // トップレベルまで上がってきた未処置の想定外のエラーなので、
+        // アプリをユーザーに強制終了してもらうようにします。
+        // ただし、アプリが起動していないため l10n リソースもロケールも使えません。
         // このためメッセージリソースをデフォルトの日本語で直接指定します。
+        final AppLocalizationsJa l10n = AppLocalizationsJa();
 
         // エラー表示専用アプリ起動
         _errorDialog.showAppBeforeLaunchErrorAlertDialog(
-          title: 'Error',
-          message: '想定外のエラーが発生しました。\n\n問題に対応できないため、アプリを終了してください。',
+          title: l10n.errorDialogTitle,
+          message: l10n.errorDialogUnexpectedErrorMessage,
         );
         debugLog('Application could not lunch.');
       }
@@ -122,14 +125,13 @@ class AppErrorHandler {
     // 既存エクセプションハンドラ処置を実行
     _oldFlutterExceptionHandler(details);
 
-    // TODO トップレベルまで上がってきた未処置のエラーなので、Crashlytics でログ記録を取ること。
-    // TODO 想定外のエラーなので、アプリをユーザーに強制終了してもらうようにすること。
-    debugLog('FlutterErrorHandler  - ${details.exception}', info: _instance);
+    // トップレベルまで上がってきた未処置の想定外のエラーなので、
+    // アプリをユーザーに強制終了してもらうようにします。
     unawaited(
       _errorDialog.showErrorAlertDialog(
         context: globalNavigatorContext,
-        title: 'Error',
-        message: '想定外のエラーが発生しました。\n\n問題に対応できないため、アプリを終了してください。',
+        title: l10n(globalNavigatorContext).errorDialogTitle,
+        message: l10n(globalNavigatorContext).errorDialogUnexpectedErrorMessage,
         isExitApp: true,
       ),
     );
@@ -146,14 +148,13 @@ class AppErrorHandler {
       _optionPlatformErrorHandler(error, stackTrace);
     }
 
-    // TODO トップレベルまで上がってきた未処置のエラーなので、Crashlytics でログ記録を取ること。
-    // TODO 想定外のエラーなので、アプリをユーザーに強制終了してもらうようにすること。
-    debugLog('PlatformDispatcher  - onError', info: _instance);
+    // トップレベルまで上がってきた未処置の想定外のエラーなので、
+    // アプリをユーザーに強制終了してもらうようにします。
     unawaited(
       _errorDialog.showErrorAlertDialog(
         context: globalNavigatorContext,
-        title: 'Error',
-        message: '想定外のエラーが発生しました。\n\n問題に対応できないため、アプリを終了してください。',
+        title: l10n(globalNavigatorContext).errorDialogTitle,
+        message: l10n(globalNavigatorContext).errorDialogUnexpectedErrorMessage,
         isExitApp: true,
       ),
     );
@@ -171,14 +172,13 @@ class AppErrorHandler {
       _optionAsynchronousErrorHandler(error, stack);
     }
 
-    // TODO トップレベルまで上がってきた未処置のエラーなので、Crashlytics でログ記録を取ること。
-    // TODO 想定外のエラーなので、アプリをユーザーに強制終了してもらうようにすること。
-    debugLog('AsynchronousErrorHandler  - $error', info: _instance);
+    // トップレベルまで上がってきた未処置の想定外のエラーなので、
+    // アプリをユーザーに強制終了してもらうようにします。
     unawaited(
       _errorDialog.showErrorAlertDialog(
         context: globalNavigatorContext,
-        title: 'Error',
-        message: '想定外のエラーが発生しました。\n\n問題に対応できないため、アプリを終了してください。',
+        title: l10n(globalNavigatorContext).errorDialogTitle,
+        message: l10n(globalNavigatorContext).errorDialogUnexpectedErrorMessage,
         isExitApp: true,
       ),
     );

--- a/lib/application/error/app_error_handler.dart
+++ b/lib/application/error/app_error_handler.dart
@@ -1,6 +1,7 @@
 // このソースファイルは、FlutterKaigi mini#2 @Ishikawa プロジェクト・ライブラリの流用です。
 // https://github.com/cch-robo/Flutter_plain_infra_mini_hands-on/blob/main/lib/src/infra/app_error_handler.dart
 
+// ignore_for_file: noop_primitive_operations
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
@@ -9,9 +10,6 @@ import 'package:search_repositories_on_github/foundation/debug/debug_logger.dart
 
 /// アプリ・エラーハンドラ設定クラス
 class AppErrorHandler {
-  /// シングルトン・インスタンス
-  static late final AppErrorHandler _instance;
-
   /// コンストラクタ
   ///
   /// _シングルトン・インスタンスのため、_<br/>
@@ -20,10 +18,14 @@ class AppErrorHandler {
     _instance = this;
   }
 
+  /// シングルトン・インスタンス
+  static late final AppErrorHandler _instance;
+
   /// アプリ起動
   ///
   /// Flutter アプリのエラーハンドラを設定して、アプリを起動します。
   void runAppWithErrorHandler(Widget app) {
+    // ignore: discarded_futures
     runZonedGuarded(() async {
       // アプリ全体のエラーハンドリングを行うため、
       // アプリ起動は、この関数パラメータ内で行う必要があることに留意。
@@ -38,7 +40,8 @@ class AppErrorHandler {
     });
 
     // Flutter フレームワーク・レベルではない、プラットフォーム由来の非同期エラーのハンドラ
-    PlatformDispatcher.instance.onError = (error, stack) {
+    PlatformDispatcher.instance.onError =
+        (Object error, StackTrace stackTrace) {
       // TODO トップレベルまで上がってきた未処置のエラーなので、Crashlytics でログ記録を取ること。
       // TODO 想定外の例外の場合は、アプリを強制終了できるようにすること。
       debugLog('PlatformDispatcher  - onError', info: _instance);
@@ -53,7 +56,8 @@ class AppErrorHandler {
   late final FlutterExceptionHandler? _optionExceptionHandler;
 
   /// オプション Flutter system error handler
-  late final Function(Object error, StackTrace stackTrace)? _optionErrorHandler;
+  late final void Function(Object error, StackTrace stackTrace)?
+      _optionErrorHandler;
 
   /// アプリ全体での Exception Handler (内部使用のみ)
   void exceptionHandler(FlutterErrorDetails details) {
@@ -65,8 +69,9 @@ class AppErrorHandler {
     FlutterError.dumpErrorToConsole(details, forceReport: true);
 
     // オプションのエクセプションハンドラ処置実行
-    if (_optionExceptionHandler != null) _optionExceptionHandler(details);
-
+    if (_optionExceptionHandler != null) {
+      _optionExceptionHandler(details);
+    }
     // 既存エクセプションハンドラ処置実行
     _oldExceptionHandler(details);
 
@@ -81,7 +86,9 @@ class AppErrorHandler {
     debugLog('StackTraces=\n${stack.toString()}');
 
     // オプションのエラーハンドラ処置実行
-    if (_optionErrorHandler != null) _optionErrorHandler(error, stack);
+    if (_optionErrorHandler != null) {
+      _optionErrorHandler(error, stack);
+    }
 
     // TODO トップレベルまで上がってきた未処置のエラーなので、Crashlytics でログ記録を取ること。
     // TODO 想定外のエラーの場合は、アプリを強制終了できるようにすること。

--- a/lib/application/error/app_error_handler.dart
+++ b/lib/application/error/app_error_handler.dart
@@ -1,0 +1,90 @@
+// このソースファイルは、FlutterKaigi mini#2 @Ishikawa プロジェクト・ライブラリの流用です。
+// https://github.com/cch-robo/Flutter_plain_infra_mini_hands-on/blob/main/lib/src/infra/app_error_handler.dart
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:search_repositories_on_github/foundation/debug/debug_logger.dart';
+
+/// アプリ・エラーハンドラ設定クラス
+class AppErrorHandler {
+  /// シングルトン・インスタンス
+  static late final AppErrorHandler _instance;
+
+  /// コンストラクタ
+  ///
+  /// _シングルトン・インスタンスのため、_<br/>
+  /// _2回目の生成はエラーとなることに注意ください。_
+  AppErrorHandler() {
+    _instance = this;
+  }
+
+  /// アプリ起動
+  ///
+  /// Flutter アプリのエラーハンドラを設定して、アプリを起動します。
+  void runAppWithErrorHandler(Widget app) {
+    runZonedGuarded(() async {
+      // アプリ全体のエラーハンドリングを行うため、
+      // アプリ起動は、この関数パラメータ内で行う必要があることに留意。
+      WidgetsFlutterBinding.ensureInitialized();
+      _oldExceptionHandler = FlutterError.onError!;
+      FlutterError.onError = exceptionHandler;
+
+      // アプリ起動
+      runApp(app);
+    }, (Object error, StackTrace stack) {
+      errorHandler(error, stack);
+    });
+
+    // Flutter フレームワーク・レベルではない、プラットフォーム由来の非同期エラーのハンドラ
+    PlatformDispatcher.instance.onError = (error, stack) {
+      // TODO トップレベルまで上がってきた未処置のエラーなので、Crashlytics でログ記録を取ること。
+      // TODO 想定外の例外の場合は、アプリを強制終了できるようにすること。
+      debugLog('PlatformDispatcher  - onError', info: _instance);
+      return true;
+    };
+  }
+
+  /// 既存 Flutter system exception handler
+  late final FlutterExceptionHandler _oldExceptionHandler;
+
+  /// オプション Flutter system exception handler
+  late final FlutterExceptionHandler? _optionExceptionHandler;
+
+  /// オプション Flutter system error handler
+  late final Function(Object error, StackTrace stackTrace)? _optionErrorHandler;
+
+  /// アプリ全体での Exception Handler (内部使用のみ)
+  void exceptionHandler(FlutterErrorDetails details) {
+    debugLog('Application ExceptionHandler');
+    debugLog('handling err type=${details.exception.runtimeType.toString()}');
+    debugLog('exceptionAsString=${details.exceptionAsString()}');
+    debugLog('StackTraces=\n${details.stack.toString()}');
+    debugLog('FlutterError.dumpErrorToConsole');
+    FlutterError.dumpErrorToConsole(details, forceReport: true);
+
+    // オプションのエクセプションハンドラ処置実行
+    if (_optionExceptionHandler != null) _optionExceptionHandler(details);
+
+    // 既存エクセプションハンドラ処置実行
+    _oldExceptionHandler(details);
+
+    // TODO トップレベルまで上がってきた未処置のエラーなので、Crashlytics でログ記録を取ること。
+    // TODO 想定外の例外の場合は、アプリを強制終了できるようにすること。
+    debugLog('exceptionHandler  - ${details.exception}', info: _instance);
+  }
+
+  /// アプリ全体での Error handler （Error だけでなく Exceptionも捕捉します）
+  void errorHandler(Object error, StackTrace stack) {
+    debugLog('Application ErrorHandler', cause: error);
+    debugLog('StackTraces=\n${stack.toString()}');
+
+    // オプションのエラーハンドラ処置実行
+    if (_optionErrorHandler != null) _optionErrorHandler(error, stack);
+
+    // TODO トップレベルまで上がってきた未処置のエラーなので、Crashlytics でログ記録を取ること。
+    // TODO 想定外のエラーの場合は、アプリを強制終了できるようにすること。
+    debugLog('errorHandler  - $error', info: _instance);
+  }
+}

--- a/lib/application/error/app_error_handler.dart
+++ b/lib/application/error/app_error_handler.dart
@@ -13,7 +13,7 @@ import 'package:search_repositories_on_github/foundation/debug/debug_logger.dart
 class AppErrorHandler {
   /// コンストラクタ
   ///
-  /// _シングルトン・インスタンスのため、_<br/>
+  /// _シングルトン・インスタンスにするため、_<br/>
   /// _2回目の生成はエラーとなることに注意ください。_
   AppErrorHandler() {
     _instance = this;
@@ -21,6 +21,11 @@ class AppErrorHandler {
 
   /// シングルトン・インスタンス
   static late final AppErrorHandler _instance;
+
+  bool _hasError = false;
+
+  /// アプリケーションレベル・エラー発生有無フラグ
+  bool get hasError => _hasError;
 
   /// アプリ起動
   ///
@@ -91,6 +96,7 @@ class AppErrorHandler {
     debugLog('StackTraces=\n${details.stack.toString()}');
     debugLog('FlutterError.dumpErrorToConsole');
     FlutterError.dumpErrorToConsole(details, forceReport: true);
+    _hasError = true;
 
     // オプションのエクセプションハンドラ処置を実行
     if (_optionFlutterExceptionHandler != null) {
@@ -109,6 +115,7 @@ class AppErrorHandler {
   bool _platformErrorHandler(Object error, StackTrace stackTrace) {
     debugLog('PlatformDispatcherErrorHandle', cause: error);
     debugLog('StackTraces=\n${stackTrace.toString()}');
+    _hasError = true;
 
     // オプションのエラーハンドラ処置を実行
     if (_optionPlatformErrorHandler != null) {
@@ -125,6 +132,7 @@ class AppErrorHandler {
   void _asynchronousErrorHandler(Object error, StackTrace stack) {
     debugLog('AsynchronousErrorHandle', cause: error);
     debugLog('StackTraces=\n${stack.toString()}');
+    _hasError = true;
 
     // オプションのエラーハンドラ処置を実行
     if (_optionAsynchronousErrorHandler != null) {

--- a/lib/application/l10n/gen/app_localizations.dart
+++ b/lib/application/l10n/gen/app_localizations.dart
@@ -109,6 +109,30 @@ abstract class AppLocalizations {
   /// In ja, this message translates to:
   /// **'Search Repo'**
   String get appTitle;
+
+  /// No description provided for @errorDialogTitle.
+  ///
+  /// In ja, this message translates to:
+  /// **'Error'**
+  String get errorDialogTitle;
+
+  /// No description provided for @errorDialogUnexpectedErrorMessage.
+  ///
+  /// In ja, this message translates to:
+  /// **'想定外のエラーが発生しました。\n\n問題に対応できないため、アプリを終了してください。'**
+  String get errorDialogUnexpectedErrorMessage;
+
+  /// No description provided for @errorButtonOk.
+  ///
+  /// In ja, this message translates to:
+  /// **'OK'**
+  String get errorButtonOk;
+
+  /// No description provided for @errorButtonCancel.
+  ///
+  /// In ja, this message translates to:
+  /// **'Cancel'**
+  String get errorButtonCancel;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/application/l10n/gen/app_localizations_en.dart
+++ b/lib/application/l10n/gen/app_localizations_en.dart
@@ -12,4 +12,17 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get appTitle => 'Search Repo';
+
+  @override
+  String get errorDialogTitle => 'Error';
+
+  @override
+  String get errorDialogUnexpectedErrorMessage =>
+      'An unexpected error has occurred.\n\nWe are unable to fix the problem so please close the app.';
+
+  @override
+  String get errorButtonOk => 'OK';
+
+  @override
+  String get errorButtonCancel => 'Cancel';
 }

--- a/lib/application/l10n/gen/app_localizations_ja.dart
+++ b/lib/application/l10n/gen/app_localizations_ja.dart
@@ -12,4 +12,17 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get appTitle => 'Search Repo';
+
+  @override
+  String get errorDialogTitle => 'Error';
+
+  @override
+  String get errorDialogUnexpectedErrorMessage =>
+      '想定外のエラーが発生しました。\n\n問題に対応できないため、アプリを終了してください。';
+
+  @override
+  String get errorButtonOk => 'OK';
+
+  @override
+  String get errorButtonCancel => 'Cancel';
 }

--- a/lib/application/l10n/resource/app_en.arb
+++ b/lib/application/l10n/resource/app_en.arb
@@ -1,4 +1,9 @@
 {
   "appDescription": "The Search Repo app uses the GitHub API to search repositories with arbitrary queries.",
-  "appTitle": "Search Repo"
+  "appTitle": "Search Repo",
+
+  "errorDialogTitle": "Error",
+  "errorDialogUnexpectedErrorMessage": "An unexpected error has occurred.\n\nWe are unable to fix the problem so please close the app.",
+  "errorButtonOk": "OK",
+  "errorButtonCancel": "Cancel"
 }

--- a/lib/application/l10n/resource/app_ja.arb
+++ b/lib/application/l10n/resource/app_ja.arb
@@ -3,5 +3,10 @@
   "@appName": {
     "description": "アプリの概要説明"
   },
-  "appTitle": "Search Repo"
+  "appTitle": "Search Repo",
+
+  "errorDialogTitle": "Error",
+  "errorDialogUnexpectedErrorMessage": "想定外のエラーが発生しました。\n\n問題に対応できないため、アプリを終了してください。",
+  "errorButtonOk": "OK",
+  "errorButtonCancel": "Cancel"
 }

--- a/lib/foundation/debug/debug_logger.dart
+++ b/lib/foundation/debug/debug_logger.dart
@@ -1,9 +1,11 @@
 // このソースファイルは、FlutterKaigi mini#2 @Ishikawa プロジェクト・ライブラリの流用です。
 // https://github.com/cch-robo/Flutter_plain_infra_mini_hands-on/blob/main/lib/src/infra/debug_logger.dart
 
+// ignore_for_file: noop_primitive_operations
 import 'package:flutter/foundation.dart';
 import 'package:search_repositories_on_github/foundation/error/default_error.dart';
 
+// ignore: avoid_classes_with_only_static_members
 class DebugLog {
   static bool isDebugMode = true;
 }
@@ -26,7 +28,7 @@ void debugLog(String message, {Object? info, Object? cause}) {
 
 String createDebugOutText(String message, {Object? info, Object? cause}) {
   if ((DebugLog.isDebugMode || cause != null) && kDebugMode) {
-    StringBuffer sb = StringBuffer();
+    final StringBuffer sb = StringBuffer();
     // メッセージ表示
     if (info != null) {
       sb.write('${info.runtimeType.toString()}: $message');
@@ -49,7 +51,9 @@ String createDebugOutText(String message, {Object? info, Object? cause}) {
         isLoop = true;
       } else {
         sb.write('\n${cause.runtimeType.toString()}: ${cause.toString()}');
-        if (cause is Error) sb.write('\n${cause.stackTrace?.toString() ?? ""}');
+        if (cause is Error) {
+          sb.write('\n${cause.stackTrace?.toString() ?? ""}');
+        }
       }
     }
 

--- a/lib/foundation/debug/debug_logger.dart
+++ b/lib/foundation/debug/debug_logger.dart
@@ -1,0 +1,59 @@
+// このソースファイルは、FlutterKaigi mini#2 @Ishikawa プロジェクト・ライブラリの流用です。
+// https://github.com/cch-robo/Flutter_plain_infra_mini_hands-on/blob/main/lib/src/infra/debug_logger.dart
+
+import 'package:flutter/foundation.dart';
+import 'package:search_repositories_on_github/foundation/error/default_error.dart';
+
+class DebugLog {
+  static bool isDebugMode = true;
+}
+
+/// デバッグ出力
+///
+/// アプリがデバックモード([kDebugMode] == true)かつ
+/// [DebugLog.isDebugMode]が true または [cause]が null でない
+/// ときのみ [message]が出力されます。
+///
+/// - [message] : 出力メッセージ
+/// - [info] : （オプション）パラメータ型を明示して出力元情報補助を行います。<br/>
+/// - [cause] : （オプション）エラーまたは例外型を明示して出力元情報補助を行います。<br/>
+/// _[Error]型が指定されていた場合は、[StackTrace]出力も伴います。_
+void debugLog(String message, {Object? info, Object? cause}) {
+  if ((DebugLog.isDebugMode || cause != null) && kDebugMode) {
+    debugPrint(createDebugOutText(message, info: info, cause: cause));
+  }
+}
+
+String createDebugOutText(String message, {Object? info, Object? cause}) {
+  if ((DebugLog.isDebugMode || cause != null) && kDebugMode) {
+    StringBuffer sb = StringBuffer();
+    // メッセージ表示
+    if (info != null) {
+      sb.write('${info.runtimeType.toString()}: $message');
+    } else {
+      sb.write(message);
+    }
+
+    // リカーシブル・エラー表示
+    bool isLoop = cause != null;
+    while (isLoop) {
+      isLoop = false;
+      if (cause is DefaultAbnormal) {
+        sb.write('\n${cause.runtimeType.toString()}: ${cause.message}');
+        sb.write('\n${cause.stackTrace?.toString() ?? ""}');
+        cause = cause.hasError
+            ? cause.error
+            : cause.hasException
+                ? cause.exception
+                : null;
+        isLoop = true;
+      } else {
+        sb.write('\n${cause.runtimeType.toString()}: ${cause.toString()}');
+        if (cause is Error) sb.write('\n${cause.stackTrace?.toString() ?? ""}');
+      }
+    }
+
+    return sb.toString();
+  }
+  return '';
+}

--- a/lib/foundation/error/default_error.dart
+++ b/lib/foundation/error/default_error.dart
@@ -1,6 +1,7 @@
 // このソースファイルは、FlutterKaigi mini#2 @Ishikawa プロジェクト・ライブラリの流用です。
 // https://github.com/cch-robo/Flutter_plain_infra_mini_hands-on/blob/main/lib/src/infra/default_error.dart
 
+// ignore_for_file: noop_primitive_operations
 import 'package:flutter/foundation.dart';
 
 /// （汎用）エラー基底クラス

--- a/lib/foundation/error/default_error.dart
+++ b/lib/foundation/error/default_error.dart
@@ -1,0 +1,153 @@
+// このソースファイルは、FlutterKaigi mini#2 @Ishikawa プロジェクト・ライブラリの流用です。
+// https://github.com/cch-robo/Flutter_plain_infra_mini_hands-on/blob/main/lib/src/infra/default_error.dart
+
+import 'package:flutter/foundation.dart';
+
+/// （汎用）エラー基底クラス
+///
+/// _独自のエラー型を定義する際の基底クラスとして利用します。_
+///
+/// ```dart
+/// // 独自エラー定義例
+/// class MyError extends DefaultError {
+///   MyError(super.message, {super.cause});
+/// }
+/// ```
+@immutable
+class DefaultError extends Error implements DefaultAbnormal {
+  DefaultError(this.message, {this.cause})
+      : error = cause is Error ? cause : null,
+        exception = cause is Exception ? cause : null,
+        stackTrace = cause is Error ? cause.stackTrace : StackTrace.current {
+    // ignore: no_runtimeType_toString
+    name = runtimeType.toString();
+  }
+
+  late final String name;
+
+  @override
+  final String message;
+
+  @override
+  late final Error? error;
+
+  @override
+  late final Exception? exception;
+
+  @override
+  late final Object? cause;
+
+  @override
+  late final StackTrace? stackTrace;
+
+  @override
+  bool get hasError => error != null;
+
+  @override
+  bool get hasException => exception != null;
+
+  @override
+  Type? get causeType => cause?.runtimeType;
+
+  @override
+  String toString() {
+    final StringBuffer sb = StringBuffer();
+    if (cause != null && exception == null && error == null) {
+      sb.write('$name on ${cause.runtimeType.toString()}: $message');
+    }
+    if (exception != null) {
+      sb.write('$name on ${exception.runtimeType.toString()}: $message');
+    }
+    if (error != null) {
+      sb.write('$name on ${error.runtimeType.toString()}: $message');
+    }
+    sb.write('\n${stackTrace?.toString() ?? ""}');
+    return sb.toString();
+  }
+}
+
+/// （汎用）例外基底クラス
+///
+/// _独自の例外型を定義する際の基底クラスとして利用します。_
+///
+/// ```dart
+/// // 独自例外定義例
+/// class MyException extends DefaultException {
+///   MyException(super.message, {super.cause});
+/// }
+/// ```
+@immutable
+class DefaultException implements Exception, DefaultAbnormal {
+  DefaultException(this.message, {this.cause})
+      : error = cause is Error ? cause : null,
+        exception = cause is Exception ? cause : null,
+        stackTrace = cause is Error ? cause.stackTrace : StackTrace.current {
+    // ignore: no_runtimeType_toString
+    name = runtimeType.toString();
+  }
+
+  late final String name;
+
+  @override
+  final String? message;
+
+  @override
+  late final Error? error;
+
+  @override
+  late final Exception? exception;
+
+  @override
+  late final Object? cause;
+
+  @override
+  late final StackTrace? stackTrace;
+
+  @override
+  bool get hasError => error != null;
+
+  @override
+  bool get hasException => exception != null;
+
+  @override
+  Type? get causeType => cause?.runtimeType;
+
+  @override
+  String toString() {
+    final StringBuffer sb = StringBuffer();
+    if (cause != null && exception == null && error == null) {
+      sb.write('$name on ${cause.runtimeType.toString()}: $message');
+    }
+    if (exception != null) {
+      sb.write('$name on ${exception.runtimeType.toString()}: $message');
+    }
+    if (error != null) {
+      sb.write('$name on ${error.runtimeType.toString()}: $message');
+    }
+    sb.write('\n${stackTrace?.toString() ?? ""}');
+    return sb.toString();
+  }
+}
+
+/// （汎用）異常系基底インターフェース
+@immutable
+abstract interface class DefaultAbnormal {
+  String? get message;
+
+  Error? get error;
+
+  Exception? get exception;
+
+  Object? get cause;
+
+  StackTrace? get stackTrace;
+
+  bool get hasError;
+
+  bool get hasException;
+
+  Type? get causeType;
+
+  @override
+  String toString();
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,29 @@
 import 'package:flutter/material.dart';
 import 'package:search_repositories_on_github/application/app_widget/app_widget.dart';
+import 'package:search_repositories_on_github/application/error/app_error_dialog.dart';
+import 'package:search_repositories_on_github/application/error/app_error_handler.dart';
 
 void main() {
-  runApp(const MyApp());
+  // アプリレベルのエラーハンドラ＆エラーダイアログ・サービス
+  final AppErrorHandler appErrorHandler = AppErrorHandler();
+  final AppErrorHandlerDialog appErrorDialog = AppErrorHandlerDialog();
+
+  // アプリ起動（アプリ全体のエラーハンドリング指定含む）
+  appErrorHandler.runAppWithErrorHandler(
+    appErrorDialog: appErrorDialog,
+    appWidget: const MyApp(),
+    appInitialize: () async {
+      // Firebase ライブラリの設定初期化などに利用します。
+    },
+    onFlutterError: (FlutterErrorDetails details) {
+      // Firebase Crashlytics クラッシュログ送信などに利用します。
+    },
+    onPlatformError: (Object exception, StackTrace stackTrace) {
+      // Firebase Crashlytics クラッシュログ送信などに利用します。
+      return false;
+    },
+    onAsynchronousError: (Object error, StackTrace stackTrace) {
+      // Firebase Crashlytics クラッシュログ送信などに利用します。
+    },
+  );
 }


### PR DESCRIPTION
# プルリクエスト説明
## 目的
このプルリクエストのアプリレベル・エラーハンドラでは、
アプリ内で見逃したか対処できなかったエラーが来ても、アプリをクラッシュさせずに、
クローズできないエラー通知ダイアログを表示して、ユーザにアプリ終了を依頼します。


以下のエラーをトラップしてエラーダイアログを表示します。

- Flutter アプリ内からのエラー
- Platform 内からのエラー
- 非同期処理内でのエラー
- アプリ起動前の処理でのエラー

また各エラーハンドラのオプションハンドラを指定できるようにして、
Firebase Crashlytics などへの対応もできるようにしています。

## 対応 ISSUE
Close #25

## 対応内容
FlutterError.onError や PlatformDispatcher.instance.onError 
および runZonedGuarded() と runApp() を組み合わせて
アプリ内で対処できなかったエラーのハンドリングを行い、
アプリをクラッシュ表示（赤い画面）させないようにして、

アプリレベル・エラー専用のダイアログで、
アプリが想定外の状況に陥ったためアプリを終了するようユーザに依頼する
エラーダイアログが表示できるようにしました。

## 妥協点
シミュレータとエミュレータでの動作確認を行いましたが、
エラーハンドリングの単体テストコードは作成していません。

## テスト
- HomePage の FABタップで例外を投げるようにしています。
![エラーハンドリング](https://github.com/user-attachments/assets/d555c2c1-6109-41cc-8adb-2bdfa90a2e23)

- アプリ起動前の `appInitialize` 処理内で例外を投げるようにしています。
![アプリ起動前エラーハンドリング](https://github.com/user-attachments/assets/cfa0a888-6e7b-4937-a335-dd267d1c5156)


## 補足
Flutter フレームワークのエラーハンドラまでエラーが到達したことは、
アプリ内部が想定外の状況になっており、処理続行できないことを示すので、
ユーザに想定外の状況になったのでアプリ終了の依頼表示ができるようにしています。

_アプリの強制終了は、Apple Human Interface より、
ユーザ以外がアプリ終了をさせてはならない規定に振れるため取り扱いません。
また Android では、アプリを終了させてもプロセスは Kill されないのでタスクリストに残り、
結局ユーザにタスクリストから手動で除外してもらうことになるので取り扱いません。_
