### PR TITLE
画面遷移先画面の雛形を新規追加

### DIFF
--- a/lib/application/app_widget/app_widget.dart
+++ b/lib/application/app_widget/app_widget.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:search_repositories_on_github/application/l10n/gen/app_localizations.dart';
 import 'package:search_repositories_on_github/application/theme/theme.dart';
-import 'package:search_repositories_on_github/presentation/home_page/page_widget/home_page_widget.dart';
+import 'package:search_repositories_on_github/presentation/search_page/page_widget/search_page_widget.dart';
 
 /// グローバルにアクセス可能な Navigator のキー
 ///
@@ -27,7 +27,7 @@ class MyApp extends StatelessWidget {
       darkTheme: createDarkThemeData(context),
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+      home: const SearchPage(title: 'Flutter Demo Home Page'),
     );
   }
 }

--- a/lib/presentation/detail_page/page_widget/detail_page_widget.dart
+++ b/lib/presentation/detail_page/page_widget/detail_page_widget.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+class DetailPage extends StatelessWidget {
+  const DetailPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    debugPrint('debug - DetailPage - build');
+    return Scaffold(
+      appBar: AppBar(title: const Text('Detail Page')),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Go back to the Results page'),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/results_page/page_widget/result_page_widget.dart
+++ b/lib/presentation/results_page/page_widget/result_page_widget.dart
@@ -11,6 +11,8 @@ class ResultsPage extends StatelessWidget {
       appBar: AppBar(title: const Text('Results Page')),
       body: Center(
         child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          mainAxisSize: MainAxisSize.max,
           children: <Widget>[
             ElevatedButton(
               onPressed: () async {

--- a/lib/presentation/results_page/page_widget/result_page_widget.dart
+++ b/lib/presentation/results_page/page_widget/result_page_widget.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:search_repositories_on_github/presentation/detail_page/page_widget/detail_page_widget.dart';
+
+class ResultsPage extends StatelessWidget {
+  const ResultsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    debugPrint('debug - ResultsPage - build');
+    return Scaffold(
+      appBar: AppBar(title: const Text('Results Page')),
+      body: Center(
+        child: Column(
+          children: <Widget>[
+            ElevatedButton(
+              onPressed: () async {
+                await Navigator.of(context).push(
+                  // ignore: argument_type_not_assignable
+                  MaterialPageRoute<void>(
+                    builder: (BuildContext context) => const DetailPage(),
+                  ),
+                );
+              },
+              child: const Text('Go to the Detail page'),
+            ),
+            ElevatedButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Go back to the Search page'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/search_page/page_widget/search_page_widget.dart
+++ b/lib/presentation/search_page/page_widget/search_page_widget.dart
@@ -1,13 +1,14 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:search_repositories_on_github/presentation/results_page/page_widget/result_page_widget.dart';
 
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({required this.title, super.key});
+class SearchPage extends StatefulWidget {
+  const SearchPage({required this.title, super.key});
 
   final String title;
 
   @override
-  State<MyHomePage> createState() => _MyHomePageState();
+  State<SearchPage> createState() => _SearchPageState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -16,7 +17,7 @@ class MyHomePage extends StatefulWidget {
   }
 }
 
-class _MyHomePageState extends State<MyHomePage> {
+class _SearchPageState extends State<SearchPage> {
   int _counter = 0;
 
   void _incrementCounter() {
@@ -42,6 +43,17 @@ class _MyHomePageState extends State<MyHomePage> {
             Text(
               '$_counter',
               style: Theme.of(context).textTheme.headlineMedium,
+            ),
+            ElevatedButton(
+              onPressed: () async {
+                await Navigator.of(context).push(
+                  // ignore: argument_type_not_assignable
+                  MaterialPageRoute<void>(
+                    builder: (BuildContext context) => const ResultsPage(),
+                  ),
+                );
+              },
+              child: const Text('Go to the Results page'),
             ),
           ],
         ),


### PR DESCRIPTION
# プルリクエスト説明
## 目的
Router を使った画面遷移機能の戦先とするため、
現状のアプリクラス（MyApp,MyHomePage）などの名前を修正し、
画面遷移させる SearchPage, ResultsPage, DetailPage の雛形を作りました。

## 対応 ISSUE
Close #29

## 対応内容
- App: MyApp から変名
- SearchPage : MyHomePage から変名
- ResultsPage: 新規追加
- DetailPage :新規追加
