### PR TITLE
lintチェックから生成コードファイルを除外するよう設定

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -6,7 +6,8 @@ analyzer:
     strict-inference: true
     strict-raw-types: true
 #  errors:
-#  exclude:
+  exclude:
+    - lib/**.g.dart
 
 formatter:
   page_width: 80


### PR DESCRIPTION
# プルリクエスト説明
## 目的
go_router では、コード生成を使って型安全ルートを実現しています。
基本的に生成コードの手動修正はできないので、
生成コードファイル *.g.dart を int ルールチェック対象から除外させます。

## 対応 ISSUE
- ISSUE: go_router 対応追加
  #32

## 対応内容
analysis_options.yaml の exclude: セクションに *.g.dart ファイル除外を追加します。

## テスト
- 効果確認報告
  analysis_options.yaml への設定追加後、make clean ＋ make get で
  Android Studio の Dart Analysis でのコード生成ファイルへの指摘が解消されました。

- 対応前
![dart_analysis_exist_alert_exist](https://github.com/user-attachments/assets/f1a45843-f7a0-4c5d-b1d6-276c0866fa31)

- 対応後
![dart_analysis_alert_solved](https://github.com/user-attachments/assets/ee7c6b7a-acd6-472f-aad8-7b4f9a2d5baa)

※残っている警告は、pubspec.yaml の項目を アルファベット順にソートしていないという指摘です。
