### PR TITLE
riverpod 導入確認の単体テストを追加

### DIFF
--- a/lib/presentation/detail_page/page_widget/detail_page_widget.dart
+++ b/lib/presentation/detail_page/page_widget/detail_page_widget.dart
@@ -15,7 +15,7 @@ class DetailPage extends ConsumerWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           mainAxisSize: MainAxisSize.max,
-          children: [
+          children: <Widget>[
             Text(
               '${ref.read(counterViewModelProvider).count}',
             ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -406,10 +406,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: "4a16b3f03741e1252fda5de3ce712666d010ba2122f8e912c94f9f7b90e1a4c3"
+      sha256: c35bb79562d980e9a453fc715854e1ed39e24e7d0297a880ef54e17f9874a9d7
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.0"
+    version: "5.1.1"
   logging:
     dependency: transitive
     description:
@@ -640,7 +640,7 @@ packages:
     source: hosted
     version: "1.2.1"
   test:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: test
       sha256: "713a8789d62f3233c46b4a90b174737b2c04cb6ae4500f2aa8b1be8f03f5e67f"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,8 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
+  test: ^1.25.8
+
   flutter_lints: ^5.0.0
 
   flutter_launcher_icons: ^0.14.2

--- a/test/riverpod_counter_unit_test.dart
+++ b/test/riverpod_counter_unit_test.dart
@@ -1,0 +1,33 @@
+import 'package:riverpod/riverpod.dart';
+import 'package:search_repositories_on_github/foundation/debug/debug_logger.dart';
+import 'package:search_repositories_on_github/presentation/search_page/page_widget/search_page_widget.dart';
+import 'package:test/test.dart';
+
+import 'riverpod_unit_test_utillity.dart';
+
+void main() {
+  test('riverpod CounterViewModel unit test', () {
+    debugLog('riverpod counterViewModel unit test');
+
+    // このテストのためにProviderContainerを作成します。
+    // テスト間でのProviderContainerの共有はしてはいけません。
+
+    // CounterState 状態モデルからカウント値を取得するテストです。
+    final ProviderContainer container = createContainer();
+    int count = container.read(counterViewModelProvider).count;
+
+    expect(
+      count,
+      equals(0),
+    );
+
+    // CounterViewModel increment で、CounterState +1 にを更新する。
+    container.read(counterViewModelProvider.notifier).increment();
+    count = container.read(counterViewModelProvider).count;
+
+    expect(
+      count,
+      equals(1),
+    );
+  });
+}

--- a/test/riverpod_counter_widget_test.dart
+++ b/test/riverpod_counter_widget_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:search_repositories_on_github/application/app_widget/app_widget.dart';
+import 'package:search_repositories_on_github/foundation/debug/debug_logger.dart';
+
+void main() {
+  testWidgets('riverpod Counter increments smoke test',
+      (WidgetTester tester) async {
+    debugLog('riverpod CounterState increments smoke test');
+    // Build our app and trigger a frame.
+    await tester.pumpWidget(const ProviderScope(child: App()));
+
+    // Verify that our counter starts at 0.
+    expect(find.text('0'), findsOneWidget);
+    expect(find.text('1'), findsNothing);
+
+    // Tap the '+' icon and trigger a frame.
+    await tester.tap(find.byIcon(Icons.add));
+    await tester.pump();
+
+    // Verify that our counter has incremented.
+    expect(find.text('0'), findsNothing);
+    expect(find.text('1'), findsOneWidget);
+  });
+}

--- a/test/riverpod_unit_test_utillity.dart
+++ b/test/riverpod_unit_test_utillity.dart
@@ -1,0 +1,26 @@
+import 'package:riverpod/riverpod.dart';
+import 'package:test/test.dart';
+// このユーティリティコードは、Riverpod 公式サイトからのコピーです。
+
+//
+// Riverpod - providerのテスト
+// https://riverpod.dev/ja/docs/essentials/testing
+
+/// [ProviderContainer]を作成し、テスト終了時に自動破棄するテストユーティリティです。
+ProviderContainer createContainer({
+  ProviderContainer? parent,
+  List<Override> overrides = const <Override>[],
+  List<ProviderObserver>? observers,
+}) {
+  // ProviderContainerを作成し、オプションでパラメータを指定します。
+  final ProviderContainer container = ProviderContainer(
+    parent: parent,
+    overrides: overrides,
+    observers: observers,
+  );
+
+  // テスト終了時、containerを破棄します。
+  addTearDown(container.dispose);
+
+  return container;
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,14 +5,14 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:search_repositories_on_github/application/app_widget/app_widget.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const App());
+    await tester.pumpWidget(const MyApp());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);
@@ -26,4 +26,75 @@ void main() {
     expect(find.text('0'), findsNothing);
     expect(find.text('1'), findsOneWidget);
   });
+}
+
+// オリジナルのテストテンプレート
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Flutter Demo',
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        useMaterial3: true,
+      ),
+      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+    );
+  }
+}
+
+class MyHomePage extends StatefulWidget {
+  const MyHomePage({required this.title, super.key});
+
+  final String title;
+
+  @override
+  State<MyHomePage> createState() => _MyHomePageState();
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(StringProperty('title', title));
+  }
+}
+
+class _MyHomePageState extends State<MyHomePage> {
+  int _counter = 0;
+
+  void _incrementCounter() {
+    setState(() {
+      _counter++;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+        title: Text(widget.title),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            const Text(
+              'You have pushed the button this many times:',
+            ),
+            Text(
+              '$_counter',
+              style: Theme.of(context).textTheme.headlineMedium,
+            ),
+          ],
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _incrementCounter,
+        tooltip: 'Increment',
+        child: const Icon(Icons.add),
+      ), // This trailing comma makes auto-formatting nicer for build methods.
+    );
+  }
 }


### PR DESCRIPTION
# プルリクエスト説明
## 目的
riverpod 導入後の動作確認 単体テストを追加
単体テストコードを使って、riverpod で状態管理させた CounterState カウント状態が、
プロバイダを介して CounterViewModel から値読み出しや値更新できることを確認

## 対応 ISSUE
- ISSUE #34

## テスト
- 現状の ScreenPage でのカウントアップの単体テスト結果です。
![riverpod_unit_test](https://github.com/user-attachments/assets/f66c9bff-9df7-48e9-8c41-5b3d1e764953)
- widget_test: flutter create で作られたときのテスト
- riverpod_counter_unit_test.dart: Flutter を介さずプロバイダのみを利用する単体テスト
- riverpod_counter_widget_test.dart: FAB タップによる画面表示変化を利用する単体テスト