### PR TITLE
riverpod 導入確認の単体テストをローカルアプリに切り替え＋画面間の状態共有確認を追加

### DIFF
--- a/test/riverpod_counter_unit_test.dart
+++ b/test/riverpod_counter_unit_test.dart
@@ -1,8 +1,8 @@
 import 'package:riverpod/riverpod.dart';
 import 'package:search_repositories_on_github/foundation/debug/debug_logger.dart';
-import 'package:search_repositories_on_github/presentation/search_page/page_widget/search_page_widget.dart';
 import 'package:test/test.dart';
 
+import 'riverpod_depend_app.dart';
 import 'riverpod_unit_test_utillity.dart';
 
 void main() {

--- a/test/riverpod_counter_widget_test.dart
+++ b/test/riverpod_counter_widget_test.dart
@@ -1,26 +1,71 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:search_repositories_on_github/application/app_widget/app_widget.dart';
 import 'package:search_repositories_on_github/foundation/debug/debug_logger.dart';
 
+import 'riverpod_depend_app.dart';
+
 void main() {
-  testWidgets('riverpod Counter increments smoke test',
+  testWidgets('riverpod - Counter increments smoke test',
       (WidgetTester tester) async {
-    debugLog('riverpod CounterState increments smoke test');
+    debugLog('riverpod - CounterState increments smoke test');
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const ProviderScope(child: App()));
+    await tester.pumpWidget(const ProviderScope(child: MyApp()));
+
+    final Finder finder = find.byKey(homePageCountKey);
+    Text homeCounterLabel = finder.evaluate().single.widget as Text;
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);
     expect(find.text('1'), findsNothing);
+    expect(homeCounterLabel.data, '0');
 
     // Tap the '+' icon and trigger a frame.
     await tester.tap(find.byIcon(Icons.add));
     await tester.pump();
+    homeCounterLabel = finder.evaluate().single.widget as Text;
 
     // Verify that our counter has incremented.
     expect(find.text('0'), findsNothing);
     expect(find.text('1'), findsOneWidget);
+    expect(homeCounterLabel.data, '1');
+  });
+
+  /// HomePage と SecondPage でカウンタ状態値の共有を確認する。
+  testWidgets('riverpod - share Counter state between pages smoke test',
+      (WidgetTester tester) async {
+    debugLog('riverpod - share Counter state between pages smoke test');
+    // Build our app and trigger a frame.
+    await tester.pumpWidget(const ProviderScope(child: MyApp()));
+
+    final Finder homeCountFinder = find.byKey(homePageCountKey);
+    Text homeCounterLabel = homeCountFinder.evaluate().single.widget as Text;
+
+    // Tap the '+' icon and trigger a frame.
+    await tester.tap(find.byIcon(Icons.add));
+    await tester.pump();
+    homeCounterLabel = homeCountFinder.evaluate().single.widget as Text;
+
+    // Verify that our counter has incremented.
+    expect(find.byType(MyHomePage), findsOneWidget);
+    expect(find.byType(MySecondPage), findsNothing);
+    expect(find.text('0'), findsNothing);
+    expect(find.text('1'), findsOneWidget);
+    expect(homeCounterLabel.data, '1');
+
+    // Tap the 'Go Second' button and trigger a frame.
+    await tester.tap(find.byKey(homePageGoSecondKey));
+    await tester.pumpAndSettle(); //画面遷移が完了するまで待機
+
+    final Finder secondCountFinder = find.byKey(secondPageCountKey);
+    Text secondCounterLabel =
+        secondCountFinder.evaluate().single.widget as Text;
+
+    // Verify that our counter has incremented.
+    expect(find.byType(MyHomePage), findsNothing);
+    expect(find.byType(MySecondPage), findsOneWidget);
+    expect(find.text('0'), findsNothing);
+    expect(find.text('1'), findsOneWidget);
+    expect(secondCounterLabel.data, '1');
   });
 }

--- a/test/riverpod_depend_app.dart
+++ b/test/riverpod_depend_app.dart
@@ -1,0 +1,129 @@
+// riverpod 依存アプリ
+// riverpod 導入のスモークテスト（基本機能動作確認）用に設けた、ローカル・アプリコードです。
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'riverpod_depend_app.g.dart';
+
+const Key homePageKey = Key('home_page');
+const Key homePageCountKey = Key('home_count');
+const Key homePageGoSecondKey = Key('home_go_second');
+
+const Key secondPageKey = Key('second_page');
+const Key secondPageCountKey = Key('second_count');
+const Key secondPageGoBackKey = Key('second_go_back');
+
+@immutable
+class CounterState {
+  const CounterState(this.count);
+
+  final int count;
+}
+
+@riverpod
+class CounterViewModel extends _$CounterViewModel {
+  CounterViewModel();
+
+  @override
+  CounterState build() {
+    return const CounterState(0);
+  }
+
+  void increment() {
+    state = CounterState(state.count + 1);
+  }
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Riverpod depend App',
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        useMaterial3: true,
+      ),
+      home: const MyHomePage(),
+    );
+  }
+}
+
+class MyHomePage extends ConsumerWidget {
+  const MyHomePage() : super(key: homePageKey);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    debugPrint('debug - MyHomePage - build');
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+        title: const Text('Home Page'),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            const Text(
+              'You have pushed the button this many times:',
+            ),
+            Text(
+              '${ref.watch(counterViewModelProvider).count}',
+              style: Theme.of(context).textTheme.headlineMedium,
+              key: homePageCountKey,
+            ),
+            ElevatedButton(
+              key: homePageGoSecondKey,
+              onPressed: () async {
+                await Navigator.of(context).push(
+                  // ignore: argument_type_not_assignable
+                  MaterialPageRoute<void>(
+                    builder: (BuildContext context) => const MySecondPage(),
+                  ),
+                );
+              },
+              child: const Text('Go to the Second page'),
+            ),
+          ],
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () =>
+            ref.read(counterViewModelProvider.notifier).increment(),
+        tooltip: 'Increment',
+        child: const Icon(Icons.add),
+      ), // This trailing comma makes auto-formatting nicer for build methods.
+    );
+  }
+}
+
+class MySecondPage extends ConsumerWidget {
+  const MySecondPage() : super(key: secondPageKey);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    debugPrint('debug - MySecondPage - build');
+    return Scaffold(
+      appBar: AppBar(title: const Text('Second Page')),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          mainAxisSize: MainAxisSize.max,
+          children: <Widget>[
+            Text(
+              '${ref.read(counterViewModelProvider).count}',
+              key: secondPageCountKey,
+            ),
+            ElevatedButton(
+              key: secondPageGoBackKey,
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Go back to the Home page'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/riverpod_depend_app.g.dart
+++ b/test/riverpod_depend_app.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'riverpod_depend_app.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$counterViewModelHash() => r'7b4e38cdc9e34f3fcb6debfdf2d1fae9c4e2cb75';
+
+/// See also [CounterViewModel].
+@ProviderFor(CounterViewModel)
+final counterViewModelProvider =
+    AutoDisposeNotifierProvider<CounterViewModel, CounterState>.internal(
+  CounterViewModel.new,
+  name: r'counterViewModelProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$counterViewModelHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$CounterViewModel = AutoDisposeNotifier<CounterState>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package


### PR DESCRIPTION
# プルリクエスト説明
## 目的
今後、アプリの構成は変化していくため、
設定確認だけの riverpod依存のローカルアプリ `riverpod_depend_app.dart` を testディレクトリ内に追加

ローカルアプリを使った単体テストとして、riverpodによる状態更新＆画面反映だけでなく、
riverpodのキーである画面間での状態共有確認として、画面遷移先での状態共有確認テストと追加

## 対応 ISSUE
- ISSUE #34

## 対応内容
1. test/ ディレクトリ配下に、riverpod依存の２画面アプリ `riverpod_depend_app.dart` を追加 
2. test/ ディレクトリ配下に、生成ファイル `riverpod_depend_app.g.dart` を追加 
3. ローカルアプリを参照するよう `riverpod_counter_unit_test` を修正
4. ローカルアプリを参照するよう  `riverpod_counter_widget_test` を修正し、
  画面間での状態共有確認テストを追加

## テスト
![riverpod_widget_test_2](https://github.com/user-attachments/assets/8d54db33-c229-4a8b-b629-f7a2671c5f16)

- テストは、Android Studio だけでなくターミナルから
  $ make unit-test または、fvm dart test test/ を実行しても確認できます。

## 補足
<!-- その他補足事項があれば、記載してください。 -->
