### PR TITLE
freezedとjson_serializableを導入

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -9,6 +9,7 @@ analyzer:
     # Workaround for freezing and json_serializable issues
     invalid_annotation_target: ignore
   exclude:
+    # see https://github.com/rrousselGit/freezed/issues/488
     - "**/*.g.dart"
     - "**/*.freezed.dart"
   plugins:

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -5,7 +5,9 @@ analyzer:
     strict-casts: true
     strict-inference: true
     strict-raw-types: true
-#  errors:
+  errors:
+    # Workaround for freezing and json_serializable issues
+    invalid_annotation_target: ignore
   exclude:
     - lib/**.g.dart
   plugins:

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -9,7 +9,8 @@ analyzer:
     # Workaround for freezing and json_serializable issues
     invalid_annotation_target: ignore
   exclude:
-    - lib/**.g.dart
+    - "**/*.g.dart"
+    - "**/*.freezed.dart"
   plugins:
     # enable riverpod_lint
     - custom_lint

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -467,13 +467,21 @@ packages:
     source: hosted
     version: "0.7.1"
   json_annotation:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: json_annotation
       sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
       url: "https://pub.dev"
     source: hosted
     version: "4.9.0"
+  json_serializable:
+    dependency: "direct dev"
+    description:
+      name: json_serializable
+      sha256: c2fcb3920cf2b6ae6845954186420fca40bc0a8abcc84903b7801f17d7050d7c
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.9.0"
   leak_tracker:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -346,8 +346,16 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  freezed:
+    dependency: "direct dev"
+    description:
+      name: freezed
+      sha256: "44c19278dd9d89292cf46e97dc0c1e52ce03275f40a97c5a348e802a924bf40e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.7"
   freezed_annotation:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: freezed_annotation
       sha256: c2e2d632dd9b8a2b7751117abcfc2b4888ecfe181bd9fca7170d9ef02e595fe2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   hooks_riverpod: ^2.6.1
   flutter_hooks: ^0.20.5
   riverpod_annotation: ^2.6.1
+  freezed_annotation: ^2.4.4
 
 dev_dependencies:
   flutter_test:
@@ -42,6 +43,7 @@ dev_dependencies:
   riverpod_generator: ^2.6.3
   custom_lint: ^0.7.0
   riverpod_lint: ^2.6.3
+  freezed: ^2.5.7
 
 flutter:
   generate: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   flutter_hooks: ^0.20.5
   riverpod_annotation: ^2.6.1
   freezed_annotation: ^2.4.4
+  json_annotation: ^4.9.0
 
 dev_dependencies:
   flutter_test:
@@ -44,6 +45,7 @@ dev_dependencies:
   custom_lint: ^0.7.0
   riverpod_lint: ^2.6.3
   freezed: ^2.5.7
+  json_serializable: ^6.9.0
 
 flutter:
   generate: true

--- a/test/freezed/person.dart
+++ b/test/freezed/person.dart
@@ -1,0 +1,19 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'person.freezed.dart';
+part 'person.g.dart';
+
+// This code is taken from the example in the freezed library's README,
+// Creating a Model using Freezed.
+// https://pub.dev/packages/freezed#creating-a-model-using-freezed:~:text=%E3%83%A2%E3%83%87%E3%83%AB%E3%81%AE%E4%BD%9C%E6%88%90-,%23,-%E9%95%B7%E3%81%84%E6%8A%BD%E8%B1%A1%E7%9A%84
+
+@freezed
+class Person with _$Person {
+  const factory Person({
+    required String firstName,
+    required String lastName,
+    required int age,
+  }) = _Person;
+
+  factory Person.fromJson(Map<String, Object?> json) => _$PersonFromJson(json);
+}

--- a/test/freezed/person.freezed.dart
+++ b/test/freezed/person.freezed.dart
@@ -1,0 +1,198 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'person.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+Person _$PersonFromJson(Map<String, dynamic> json) {
+  return _Person.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Person {
+  String get firstName => throw _privateConstructorUsedError;
+  String get lastName => throw _privateConstructorUsedError;
+  int get age => throw _privateConstructorUsedError;
+
+  /// Serializes this Person to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of Person
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $PersonCopyWith<Person> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $PersonCopyWith<$Res> {
+  factory $PersonCopyWith(Person value, $Res Function(Person) then) =
+      _$PersonCopyWithImpl<$Res, Person>;
+  @useResult
+  $Res call({String firstName, String lastName, int age});
+}
+
+/// @nodoc
+class _$PersonCopyWithImpl<$Res, $Val extends Person>
+    implements $PersonCopyWith<$Res> {
+  _$PersonCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of Person
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? firstName = null,
+    Object? lastName = null,
+    Object? age = null,
+  }) {
+    return _then(_value.copyWith(
+      firstName: null == firstName
+          ? _value.firstName
+          : firstName // ignore: cast_nullable_to_non_nullable
+              as String,
+      lastName: null == lastName
+          ? _value.lastName
+          : lastName // ignore: cast_nullable_to_non_nullable
+              as String,
+      age: null == age
+          ? _value.age
+          : age // ignore: cast_nullable_to_non_nullable
+              as int,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$PersonImplCopyWith<$Res> implements $PersonCopyWith<$Res> {
+  factory _$$PersonImplCopyWith(
+          _$PersonImpl value, $Res Function(_$PersonImpl) then) =
+      __$$PersonImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String firstName, String lastName, int age});
+}
+
+/// @nodoc
+class __$$PersonImplCopyWithImpl<$Res>
+    extends _$PersonCopyWithImpl<$Res, _$PersonImpl>
+    implements _$$PersonImplCopyWith<$Res> {
+  __$$PersonImplCopyWithImpl(
+      _$PersonImpl _value, $Res Function(_$PersonImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of Person
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? firstName = null,
+    Object? lastName = null,
+    Object? age = null,
+  }) {
+    return _then(_$PersonImpl(
+      firstName: null == firstName
+          ? _value.firstName
+          : firstName // ignore: cast_nullable_to_non_nullable
+              as String,
+      lastName: null == lastName
+          ? _value.lastName
+          : lastName // ignore: cast_nullable_to_non_nullable
+              as String,
+      age: null == age
+          ? _value.age
+          : age // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$PersonImpl implements _Person {
+  const _$PersonImpl(
+      {required this.firstName, required this.lastName, required this.age});
+
+  factory _$PersonImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PersonImplFromJson(json);
+
+  @override
+  final String firstName;
+  @override
+  final String lastName;
+  @override
+  final int age;
+
+  @override
+  String toString() {
+    return 'Person(firstName: $firstName, lastName: $lastName, age: $age)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PersonImpl &&
+            (identical(other.firstName, firstName) ||
+                other.firstName == firstName) &&
+            (identical(other.lastName, lastName) ||
+                other.lastName == lastName) &&
+            (identical(other.age, age) || other.age == age));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, firstName, lastName, age);
+
+  /// Create a copy of Person
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PersonImplCopyWith<_$PersonImpl> get copyWith =>
+      __$$PersonImplCopyWithImpl<_$PersonImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$PersonImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _Person implements Person {
+  const factory _Person(
+      {required final String firstName,
+      required final String lastName,
+      required final int age}) = _$PersonImpl;
+
+  factory _Person.fromJson(Map<String, dynamic> json) = _$PersonImpl.fromJson;
+
+  @override
+  String get firstName;
+  @override
+  String get lastName;
+  @override
+  int get age;
+
+  /// Create a copy of Person
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$PersonImplCopyWith<_$PersonImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/test/freezed/person.g.dart
+++ b/test/freezed/person.g.dart
@@ -1,0 +1,20 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'person.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$PersonImpl _$$PersonImplFromJson(Map<String, dynamic> json) => _$PersonImpl(
+      firstName: json['firstName'] as String,
+      lastName: json['lastName'] as String,
+      age: (json['age'] as num).toInt(),
+    );
+
+Map<String, dynamic> _$$PersonImplToJson(_$PersonImpl instance) =>
+    <String, dynamic>{
+      'firstName': instance.firstName,
+      'lastName': instance.lastName,
+      'age': instance.age,
+    };

--- a/test/freezed/team.dart
+++ b/test/freezed/team.dart
@@ -1,0 +1,17 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'person.dart';
+
+part 'team.freezed.dart';
+part 'team.g.dart';
+
+@freezed
+class Team with _$Team {
+  @JsonSerializable(explicitToJson: true)
+  const factory Team({
+    @JsonKey(name: 'team_id') required String teamId,
+    required List<Person> persons,
+  }) = _Team;
+
+  factory Team.fromJson(Map<String, Object?> json) => _$TeamFromJson(json);
+}

--- a/test/freezed/team.freezed.dart
+++ b/test/freezed/team.freezed.dart
@@ -1,0 +1,190 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'team.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+Team _$TeamFromJson(Map<String, dynamic> json) {
+  return _Team.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Team {
+  @JsonKey(name: 'team_id')
+  String get teamId => throw _privateConstructorUsedError;
+  List<Person> get persons => throw _privateConstructorUsedError;
+
+  /// Serializes this Team to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of Team
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $TeamCopyWith<Team> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $TeamCopyWith<$Res> {
+  factory $TeamCopyWith(Team value, $Res Function(Team) then) =
+      _$TeamCopyWithImpl<$Res, Team>;
+  @useResult
+  $Res call({@JsonKey(name: 'team_id') String teamId, List<Person> persons});
+}
+
+/// @nodoc
+class _$TeamCopyWithImpl<$Res, $Val extends Team>
+    implements $TeamCopyWith<$Res> {
+  _$TeamCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of Team
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? teamId = null,
+    Object? persons = null,
+  }) {
+    return _then(_value.copyWith(
+      teamId: null == teamId
+          ? _value.teamId
+          : teamId // ignore: cast_nullable_to_non_nullable
+              as String,
+      persons: null == persons
+          ? _value.persons
+          : persons // ignore: cast_nullable_to_non_nullable
+              as List<Person>,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$TeamImplCopyWith<$Res> implements $TeamCopyWith<$Res> {
+  factory _$$TeamImplCopyWith(
+          _$TeamImpl value, $Res Function(_$TeamImpl) then) =
+      __$$TeamImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({@JsonKey(name: 'team_id') String teamId, List<Person> persons});
+}
+
+/// @nodoc
+class __$$TeamImplCopyWithImpl<$Res>
+    extends _$TeamCopyWithImpl<$Res, _$TeamImpl>
+    implements _$$TeamImplCopyWith<$Res> {
+  __$$TeamImplCopyWithImpl(_$TeamImpl _value, $Res Function(_$TeamImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of Team
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? teamId = null,
+    Object? persons = null,
+  }) {
+    return _then(_$TeamImpl(
+      teamId: null == teamId
+          ? _value.teamId
+          : teamId // ignore: cast_nullable_to_non_nullable
+              as String,
+      persons: null == persons
+          ? _value._persons
+          : persons // ignore: cast_nullable_to_non_nullable
+              as List<Person>,
+    ));
+  }
+}
+
+/// @nodoc
+
+@JsonSerializable(explicitToJson: true)
+class _$TeamImpl implements _Team {
+  const _$TeamImpl(
+      {@JsonKey(name: 'team_id') required this.teamId,
+      required final List<Person> persons})
+      : _persons = persons;
+
+  factory _$TeamImpl.fromJson(Map<String, dynamic> json) =>
+      _$$TeamImplFromJson(json);
+
+  @override
+  @JsonKey(name: 'team_id')
+  final String teamId;
+  final List<Person> _persons;
+  @override
+  List<Person> get persons {
+    if (_persons is EqualUnmodifiableListView) return _persons;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_persons);
+  }
+
+  @override
+  String toString() {
+    return 'Team(teamId: $teamId, persons: $persons)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$TeamImpl &&
+            (identical(other.teamId, teamId) || other.teamId == teamId) &&
+            const DeepCollectionEquality().equals(other._persons, _persons));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, teamId, const DeepCollectionEquality().hash(_persons));
+
+  /// Create a copy of Team
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$TeamImplCopyWith<_$TeamImpl> get copyWith =>
+      __$$TeamImplCopyWithImpl<_$TeamImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$TeamImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _Team implements Team {
+  const factory _Team(
+      {@JsonKey(name: 'team_id') required final String teamId,
+      required final List<Person> persons}) = _$TeamImpl;
+
+  factory _Team.fromJson(Map<String, dynamic> json) = _$TeamImpl.fromJson;
+
+  @override
+  @JsonKey(name: 'team_id')
+  String get teamId;
+  @override
+  List<Person> get persons;
+
+  /// Create a copy of Team
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$TeamImplCopyWith<_$TeamImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/test/freezed/team.g.dart
+++ b/test/freezed/team.g.dart
@@ -1,0 +1,20 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'team.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$TeamImpl _$$TeamImplFromJson(Map<String, dynamic> json) => _$TeamImpl(
+      teamId: json['team_id'] as String,
+      persons: (json['persons'] as List<dynamic>)
+          .map((e) => Person.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$$TeamImplToJson(_$TeamImpl instance) =>
+    <String, dynamic>{
+      'team_id': instance.teamId,
+      'persons': instance.persons.map((e) => e.toJson()).toList(),
+    };

--- a/test/freezed_json_unit_test.dart
+++ b/test/freezed_json_unit_test.dart
@@ -1,0 +1,47 @@
+import 'dart:convert';
+
+import 'package:search_repositories_on_github/foundation/debug/debug_logger.dart';
+import 'package:test/test.dart';
+
+import 'freezed/person.dart';
+import 'freezed/team.dart';
+
+void main() {
+  test('freezed json serialize/deserialize unit test', () {
+    debugLog('freezed json serialize/deserialize unit test');
+
+    // モデルデータを直接生成
+    const Person peter = Person(
+      firstName: 'Peter',
+      lastName: 'Parker',
+      age: 19,
+    );
+    const Person jane = Person(
+      firstName: 'Merry Jane',
+      lastName: 'Watson',
+      age: 19,
+    );
+    const Team team1 =
+        Team(teamId: 'Spider Man', persons: <Person>[peter, jane]);
+
+    // モデルデータを Json Text から生成
+    // ignore: lines_longer_than_80_chars
+    const String jsonText =
+        '{"team_id":"Spider Man","persons":[{"firstName":"Peter","lastName":"Parker","age":19},{"firstName":"Merry Jane","lastName":"Watson","age":19}]}';
+    final Team team2 =
+        Team.fromJson(json.decode(jsonText) as Map<String, dynamic>);
+
+    debugLog('team1=${json.encode(team1.toJson())}');
+    debugLog('team2=$jsonText');
+
+    expect(
+      team1,
+      equals(team2),
+    );
+
+    expect(
+      json.encode(team1.toJson()),
+      equals(jsonText),
+    );
+  });
+}

--- a/test/freezed_json_unit_test.dart
+++ b/test/freezed_json_unit_test.dart
@@ -25,9 +25,10 @@ void main() {
         Team(teamId: 'Spider Man', persons: <Person>[peter, jane]);
 
     // モデルデータを Json Text から生成
-    // ignore: lines_longer_than_80_chars
-    const String jsonText =
-        '{"team_id":"Spider Man","persons":[{"firstName":"Peter","lastName":"Parker","age":19},{"firstName":"Merry Jane","lastName":"Watson","age":19}]}';
+    // ignore: missing_whitespace_between_adjacent_strings
+    const String jsonText = '{"team_id":"Spider Man","persons":['
+        '{"firstName":"Peter","lastName":"Parker","age":19},'
+        '{"firstName":"Merry Jane","lastName":"Watson","age":19}]}';
     final Team team2 =
         Team.fromJson(json.decode(jsonText) as Map<String, dynamic>);
 


### PR DESCRIPTION
# プルリクエスト説明
## 目的
不変値モデルを作るに当たり freezed を導入し、
一緒に json_serializable も導入して JSON デコード/エンコードをできるようにしました。

## 対応 ISSUE
Clode #38

## テスト
- `test/freezed_json_unit_test.dart`: ネストリスト構造データの JSON シリアライズ/デシリアライズ確認
- `test/freezed/person.dart`: 単純な氏名と年齢のデータ構造モデル
- `test/freezed/team.dart`: personリストを持つネストリスト・データ構造モデル
![freezed_unit_test](https://github.com/user-attachments/assets/1ca0b7ca-6757-43b6-8ab7-03339a8511f5)

## 備考
freezed の機能チェックではなく、
freezedとjson_serializable導入に当たり、ネストリスト構造データの設定認識ミスがないことの確認用です。

GitHub 障害のためプルリクエスト作成中断中
https://x.com/githubstatusjp/status/1877171019879952617