### PR TITLE
HTTP 通信ライブラリ Dio を導入して、GitHub Search API レスポンス取得までを確認

### DIFF
--- a/lib/domain/rest_api/rest_api_service.dart
+++ b/lib/domain/rest_api/rest_api_service.dart
@@ -6,14 +6,23 @@ import 'package:search_repositories_on_github/foundation/error/default_error.dar
 class RestApiService {
   RestApiService();
 
-  final Dio _dio = Dio();
+  final Dio _dio = Dio(
+    BaseOptions(
+      // 接続タイムアウト
+      connectTimeout: const Duration(seconds: 5),
+      // データ送信タイムアウト
+      sendTimeout: const Duration(seconds: 5),
+      // データ受信タイムアウト
+      receiveTimeout: const Duration(seconds: 60),
+    ),
+  );
 
   Future<Response<Map<String, dynamic>>> get({
     required String path,
     Map<String, String> header = const <String, String>{},
     Map<String, dynamic>? queries,
   }) async {
-    _debugRequest('get', queries);
+    _debugRequest('[GET]', queries);
     try {
       header.keys.map((String key) {
         _dio.options.headers[key] = header[key];
@@ -21,28 +30,35 @@ class RestApiService {
       final Response<Map<String, dynamic>> response =
           await _dio.get<Map<String, dynamic>>(
         path,
-        queryParameters: queries ?? {},
+        queryParameters: queries ?? <String, dynamic>{},
       );
-      _debugResponse('get', response);
+      _debugResponse('[GET]', response);
 
       return response;
     } on DioException catch (exception) {
-      _debugDioException('get', exception);
-      throw DefaultException('', cause: exception);
+      // タイムアウト
+      if (exception.type == DioExceptionType.connectionTimeout ||
+          exception.type == DioExceptionType.sendTimeout ||
+          exception.type == DioExceptionType.receiveTimeout) {
+        debugLog('[GET] request timed out', cause: exception);
+      } else {
+        _debugDioException('[GET]', exception);
+      }
+      throw DefaultException('[GET] DioException', cause: exception);
     } catch (e) {
       _debugUnExpected('get', e);
-      throw DefaultError('get unexpected', cause: e);
+      throw DefaultError('[GET] unexpected', cause: e);
     }
   }
 
   Future<Response<Map<String, dynamic>>> post({
     required String path,
-    Map<String, String> header = const <String, String>{},
     required Map<String, dynamic> data,
+    Map<String, String> header = const <String, String>{},
     Map<String, dynamic>? queries,
   }) async {
-    _debugRequest('post', data);
-    _debugRequest('post', queries);
+    _debugRequest('[POST]', data);
+    _debugRequest('[POST]', queries);
     try {
       header.keys.map((String key) {
         _dio.options.headers[key] = header[key];
@@ -51,17 +67,24 @@ class RestApiService {
           await _dio.post<Map<String, dynamic>>(
         path,
         data: data,
-        queryParameters: queries ?? {},
+        queryParameters: queries ?? <String, dynamic>{},
       );
-      _debugResponse('post', response);
+      _debugResponse('[POST]', response);
 
       return response;
     } on DioException catch (exception) {
-      _debugDioException('post', exception);
-      throw DefaultException('', cause: exception);
+      // タイムアウト
+      if (exception.type == DioExceptionType.connectionTimeout ||
+          exception.type == DioExceptionType.sendTimeout ||
+          exception.type == DioExceptionType.receiveTimeout) {
+        debugLog('[POST] request timed out', cause: exception);
+      } else {
+        _debugDioException('[POST]', exception);
+      }
+      throw DefaultException('[POST] DioException', cause: exception);
     } catch (e) {
-      _debugUnExpected('post', e);
-      throw DefaultError('post unexpected', cause: e);
+      _debugUnExpected('[POST]', e);
+      throw DefaultError('[POST] unexpected', cause: e);
     }
   }
 

--- a/lib/domain/rest_api/rest_api_service.dart
+++ b/lib/domain/rest_api/rest_api_service.dart
@@ -1,0 +1,45 @@
+import 'package:dio/dio.dart';
+
+class RestApiService {
+  RestApiService();
+
+  final Dio _dio = Dio();
+
+  Future<Response?> get({
+    required String path,
+    Map<String, dynamic>? queries,
+  }) async {
+    try {
+      final Response response = await _dio.get(
+        path,
+        queryParameters: queries ?? {},
+      );
+
+      return response;
+    } on DioException catch (exception) {
+      rethrow;
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  Future<Response?> post({
+    required String path,
+    required Map<String, dynamic> data,
+    Map<String, dynamic>? queries,
+  }) async {
+    try {
+      final Response response = await _dio.post(
+        path,
+        data: data,
+        queryParameters: queries ?? {},
+      );
+
+      return response;
+    } on DioException catch (exception) {
+      rethrow;
+    } catch (e) {
+      rethrow;
+    }
+  }
+}

--- a/lib/domain/rest_api/rest_api_service.dart
+++ b/lib/domain/rest_api/rest_api_service.dart
@@ -1,45 +1,118 @@
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+import 'package:search_repositories_on_github/foundation/debug/debug_logger.dart';
+import 'package:search_repositories_on_github/foundation/error/default_error.dart';
 
 class RestApiService {
   RestApiService();
 
   final Dio _dio = Dio();
 
-  Future<Response?> get({
+  Future<Response<Map<String, dynamic>>> get({
     required String path,
+    Map<String, String> header = const <String, String>{},
     Map<String, dynamic>? queries,
   }) async {
+    _debugRequest('get', queries);
     try {
-      final Response response = await _dio.get(
+      header.keys.map((String key) {
+        _dio.options.headers[key] = header[key];
+      });
+      final Response<Map<String, dynamic>> response =
+          await _dio.get<Map<String, dynamic>>(
         path,
         queryParameters: queries ?? {},
       );
+      _debugResponse('get', response);
 
       return response;
     } on DioException catch (exception) {
-      rethrow;
+      _debugDioException('get', exception);
+      throw DefaultException('', cause: exception);
     } catch (e) {
-      rethrow;
+      _debugUnExpected('get', e);
+      throw DefaultError('get unexpected', cause: e);
     }
   }
 
-  Future<Response?> post({
+  Future<Response<Map<String, dynamic>>> post({
     required String path,
+    Map<String, String> header = const <String, String>{},
     required Map<String, dynamic> data,
     Map<String, dynamic>? queries,
   }) async {
+    _debugRequest('post', data);
+    _debugRequest('post', queries);
     try {
-      final Response response = await _dio.post(
+      header.keys.map((String key) {
+        _dio.options.headers[key] = header[key];
+      });
+      final Response<Map<String, dynamic>> response =
+          await _dio.post<Map<String, dynamic>>(
         path,
         data: data,
         queryParameters: queries ?? {},
       );
+      _debugResponse('post', response);
 
       return response;
     } on DioException catch (exception) {
-      rethrow;
+      _debugDioException('post', exception);
+      throw DefaultException('', cause: exception);
     } catch (e) {
-      rethrow;
+      _debugUnExpected('post', e);
+      throw DefaultError('post unexpected', cause: e);
     }
+  }
+
+  void _debugRequest(String method, Map<String, dynamic>? data) {
+    if (!kDebugMode) {
+      return;
+    }
+    debugLog(
+      'debug - $method request - data=${data ?? ""}\n',
+    );
+  }
+
+  void _debugResponse(String method, Response<Map<String, dynamic>> response) {
+    if (!kDebugMode) {
+      return;
+    }
+    debugLog(
+      'debug - $method response {\n'
+      '    request.uri: ${response.requestOptions.uri}\n'
+      '    response.statusCode: ${response.statusCode ?? ""}\n'
+      '    response.data: ${response.data ?? ""}\n'
+      '    response.headers: ${response.headers}\n'
+      '}\n',
+    );
+  }
+
+  void _debugDioException(String method, DioException exception) {
+    if (!kDebugMode) {
+      return;
+    }
+    debugLog(
+      'debug - $method exception {\n'
+      '    requestOptions.path: ${exception.requestOptions.path}\n'
+      '    requestOptions.data: ${exception.requestOptions.data ?? ""}\n'
+      '    message: ${exception.message ?? ""}\n'
+      '    response.statusCode: ${exception.response?.statusCode ?? ""}\n'
+      '    response.data: ${exception.response?.data ?? ""}\n'
+      '    error: ${exception.error}\n'
+      '    stackTrace: ${exception.stackTrace}\n'
+      '}\n',
+      cause: exception,
+    );
+  }
+
+  void _debugUnExpected(String method, Object exception) {
+    if (!kDebugMode) {
+      return;
+    }
+    debugLog(
+      'debug - $method unexpected',
+      cause: exception,
+    );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -262,6 +262,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.7"
+  dio:
+    dependency: "direct main"
+    description:
+      name: dio
+      sha256: "5598aa796bbf4699afd5c67c0f5f6e2ed542afc956884b9cd58c306966efc260"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.7.0"
+  dio_web_adapter:
+    dependency: transitive
+    description:
+      name: dio_web_adapter
+      sha256: "33259a9276d6cea88774a0000cfae0d861003497755969c92faa223108620dc8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,8 @@ dependencies:
   flutter_hooks: ^0.20.5
   riverpod_annotation: ^2.6.1
 
+  dio: ^5.7.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
# プルリクエスト説明
## 目的
GitHub Search API を利用するため HTTP 通信ライブラリ Dio を導入

動作確認として対応 ISSU の範囲外ですが
GitHub Serach API を最低限コールできるレベルの RestApiService を追加しています。

## 対応 ISSUE
Close #39 

## 対応内容
1. Dio ライブラリを導入
2. GitHub Serach API をアクセス可能な 
  最低限の REST API Service 実装（RestApiService）を追加

## 妥協点
RestApiService は、取得レスポンスを json データとして取り扱うまでの段階です。

## テスト
RestApiService を使い ①のパラメータ内容で、

- GET メソッド・パラメータ指定①で、検索レスポンス② が取得できた。
```dart
RestApiService api = RestApiService();
await api.get(
  path: 'https://api.github.com/search/repositories',
  header: {
    "Accept": 'application/vnd.github+json',
    "X-GitHub-Api-Version": "2022-11-28",
  },
  queries: {
    "q": "$description in:description $readme in:readme $readme2 in:readme",
    "sort": "updated",
    "order": "desc",
    "per_page": 2,
    "page": 1,
  },
);
```

- RestApiService レスポンス②
```sh
flutter: debug - [GET] request - data={q: FlutterKaigi in:description FlutterKaigi in:readme ハンズオン in:readme, sort: updated, order: desc, per_page: 2, page: 1}
flutter:
flutter: debug - [GET] response {
flutter:     request.uri: https://api.github.com/search/repositories?q=FlutterKaigi+in%3Adescription+FlutterKaigi+in%3Areadme+%E3%83%8F%E3%83%B3%E3%82%BA%E3%82%AA%E3%83%B3+in%3Areadme&sort=updated&order=desc&per_page=2&page=1
flutter:     response.statusCode: 200
flutter:     response.data: {total_count: 4, incomplete_results: false, items: [{id: 854394770, node_id: R_kgDOMu0Hkg, name: Flutter_plain_infra_mini_hands-on, full_name: cch-robo/Flutter_plain_infra_mini_hands-on, private: false, owner: {login: cch-robo, id: 1736943, node_id: MDQ6VXNlcjE3MzY5NDM=, avatar_url: https://avatars.githubusercontent.com/u/1736943?v=4, gravatar_id: , url: https://api.github.com/users/cch-robo, html_url: https://github.com/cch-robo, followers_url: https://api.github.com/users/cch-robo/followers, following_url: https://api.github.com/users/cch-robo/following{/other_user}, gists_url: https://api.github.com/users/cch-robo/gists{/gist_id}, starred_url: https://api.github.com/users/cch-robo/starred{/owner}{/repo}, subscriptions_url: https://api.github.com/users/cch-robo/subscriptions, organizations_url: https://api.github.com/users/cch-robo/orgs, repos_url: https://api.github.com/users/cch-robo/repos, events_url: https://api.github.com/users/cch-robo/events{/privacy}, recei<…>
flutter:     response.headers: date: Thu, 09 Jan 2025 06:46:12 GMT
flutter: x-ratelimit-limit: 10
flutter: x-ratelimit-reset: 1736405232
flutter: transfer-encoding: chunked
flutter: vary: Accept,Accept-Encoding, Accept, X-Requested-With
flutter: content-encoding: gzip
flutter: access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset
flutter: x-ratelimit-remaining: 9
flutter: server: github.com
flutter: x-ratelimit-used: 1
flutter: x-github-request-id: DF97:EDB44:4698B3:532805:677F70B4
flutter: accept-ranges: bytes
flutter: x-frame-options: deny
flutter: content-security-policy: default-src 'none'
flutter: cache-control: no-cache
flutter: access-control-allow-origin: *
flutter: strict-transport-security: max-age=31536000; includeSubdomains; preload
flutter: referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
flutter: content-type: application/json; charset=utf-8
flutter: x-xss-protection: 0
flutter: link: <https://api.github.com/search/repositories?q=FlutterKaigi+in%3Adescription+FlutterKaigi+in%3Areadme+%E3%83%8F%E3%83%B3%E3%82%BA%E3%82%AA%E3%83%B3+in%3Areadme&sort=updated&order=desc&per_page=2&page=2>; rel="next", <https://api.github.com/search/repositories?q=FlutterKaigi+in%3Adescription+FlutterKaigi+in%3Areadme+%E3%83%8F%E3%83%B3%E3%82%BA%E3%82%AA%E3%83%B3+in%3Areadme&sort=updated&order=desc&per_page=2&page=2>; rel="last"
flutter: x-github-api-version-selected: 2022-11-28
flutter: x-ratelimit-resource: search
flutter: x-content-type-options: nosniff
flutter: x-github-media-type: github.v3; format=json
flutter:
flutter: }
```
