### PR TITLE
GitHub Search Repository API レスポンス改変モデルと検索フィルタを新規追加

### DIFF
--- a/lib/domain/models/search_filers.dart
+++ b/lib/domain/models/search_filers.dart
@@ -1,0 +1,121 @@
+/// Queryを表すバリュークラス
+class Query {
+  Query(this.params);
+  final List<QueryItem> params;
+
+  String toQueryStr() {
+    final StringBuffer sb = StringBuffer();
+    for (final QueryItem item in params) {
+      if (sb.isNotEmpty) {
+        sb.write(' ');
+      }
+      sb.write(item.label);
+    }
+    return sb.toString();
+  }
+}
+
+/// Queryアイテムを表すバリュークラス
+class QueryItem {
+  QueryItem(this.label);
+  final String label;
+}
+
+/// （検索条件フィルタ）キーワードが条件に含まれているリポジトリで絞り込みます。
+enum InFilter {
+  /// in:name キーワードがリポジトリ名に含まれている。
+  name('in:name'),
+
+  /// in:description キーワードがリポジトリ名または説明に含まれている。
+  description('in:description'),
+
+  /// in:topics キーワードがトピックのラベルに含まれている。
+  topics('in:topics'),
+
+  /// in:readme キーワードがREADME ファイル内に含まれている。
+  readme('in:readme');
+
+  const InFilter(this.searchType);
+
+  final String searchType;
+
+  QueryItem toQueryItem(String keyword) {
+    return QueryItem('"$keyword" $searchType');
+  }
+}
+
+//FIXME ロジック考慮中
+/// （検索条件フィルタ）条件が範囲内のリポジトリで絞り込みます。
+enum RangeFilter {
+  size('size'),
+  followers('followers'),
+  forks('forks'),
+  stars('start'),
+  topics('topics');
+
+  const RangeFilter(this.label);
+  final String label;
+  QueryItem toQueryItem({required Range range, required int value}) =>
+      QueryItem('$label:"$name"');
+}
+
+//FIXME ロジック考慮中
+enum Range {
+  equals(),
+  large,
+  small,
+  range;
+}
+
+/// （検索条件フィルタ）キーワードが条件に含まれているリポジトリで絞り込みます。
+enum SingleMachFilter {
+  /// キーワードがユーザ名に含まれている。
+  user('user'),
+
+  /// キーワードが組織名に含まれている。
+  org('org');
+
+  const SingleMachFilter(this.label);
+  final String label;
+  QueryItem toQueryItem({required String name}) => QueryItem('$label:"$name"');
+}
+
+/// （検索条件フィルタ）キーワードが条件に含まれているリポジトリで絞り込みます。
+enum DoubleMachFilter {
+  /// オーナー名やリポジトリ名で絞り込みます。
+  repo('repo');
+
+  const DoubleMachFilter(this.label);
+  final String label;
+  QueryItem toQueryItem({required String userName, required String repoName}) =>
+      QueryItem('$label:"$userName"/"$repoName"');
+}
+
+/// （検索条件フィルタ）条件を満たすリポジトリで絞り込みます。
+enum BoolFilter {
+  /// リポジトリがミラーか否かで絞り込みます。
+  mirror('mirror'),
+
+  /// リポジトリがテンプレートか否かで絞込みます。
+  template('template'),
+
+  /// リポジトリがアーカイブされているか否かで絞込みます。
+  archived('archived');
+
+  const BoolFilter(this.label);
+  final String label;
+  QueryItem toQueryItem({required bool flag}) => QueryItem('$label:$flag');
+}
+
+/// （検索条件フィルタ）条件を満たすリポジトリで絞り込みます。
+enum SingleFilter {
+  /// GitHub Sponsors リポジトリで絞り込みます。
+  sponsorable('is:sponsorable'),
+
+  /// リポジトリに Founding ファイルがあるか否かで絞り込みます。
+  fundingFile('has:funding-file');
+
+  const SingleFilter(this.label);
+  final String label;
+  QueryItem toQueryItem() => QueryItem(label);
+}

--- a/lib/domain/models/search_repositories_info_model.dart
+++ b/lib/domain/models/search_repositories_info_model.dart
@@ -1,0 +1,61 @@
+import 'package:search_repositories_on_github/domain/models/searched_repository_model.dart';
+
+/// リポジトリ検索モデル
+///
+/// リポジトリ検索結果の情報を表すモデルです。
+class SearchRepoInfoModel {
+  /// ファクトリ・コンストラクタ
+  factory SearchRepoInfoModel({
+    required Map<String, dynamic> json,
+    required String query,
+    required int parPage,
+    required int page,
+  }) {
+    final int totalCount = json['total_count'] as int;
+    final List<dynamic> items = json['items'] as List<dynamic>;
+    final SearchRepoInfoModel info = SearchRepoInfoModel._(
+      totalCount: totalCount,
+      query: query,
+      parPage: parPage,
+      page: page,
+    );
+
+    final List<Map<String, dynamic>> jsonList =
+        items.map((dynamic item) => item as Map<String, dynamic>).toList();
+
+    // リポジトリ情報を新規追加
+    for (final Map<String, dynamic> json in jsonList) {
+      info._repositories.add(RepoModel.fromJson(json));
+    }
+    return info;
+  }
+
+  /// プライベート・コンストラクタ
+  SearchRepoInfoModel._({
+    required this.totalCount,
+    required this.query,
+    required this.parPage,
+    required this.page,
+  });
+
+  /// 検索リポジトリ数
+  final int totalCount;
+
+  /// 検索クエリ情報
+  final String query;
+
+  /// 検索されたリポジトリのリスト
+  final List<RepoModel> _repositories = <RepoModel>[];
+
+  /// １ページ単位のリポジトリ数
+  final int parPage;
+
+  /// カレントページ番号
+  final int page;
+
+  List<RepoModel> get repositories {
+    final List<RepoModel> copy = <RepoModel>[];
+    copy.addAll(_repositories);
+    return copy;
+  }
+}

--- a/lib/domain/models/searched_repository_model.dart
+++ b/lib/domain/models/searched_repository_model.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/foundation.dart';
+
+/// リポジトリモデル
+///
+/// 検索されたリポジトリ情報を表すモデルです。
+@immutable
+class RepoModel {
+  const RepoModel({
+    required this.id,
+    required this.name,
+    required this.fullName,
+    required this.htmlUrl,
+    required this.description,
+    required this.ownerName,
+    required this.ownerAvatarUrl,
+    required this.language,
+    required this.startsCount,
+    required this.watchersCount,
+    required this.forksCount,
+    required this.issuesCount,
+    required this.isPrivate,
+    required this.isArchived,
+    required this.isDisabled,
+  });
+
+  factory RepoModel.fromJson(Map<String, dynamic> json) {
+    final Map<String, dynamic> owner = json['owner'] as Map<String, dynamic>;
+    final String? ownerName = owner['login'] as String?;
+    final String? ownerAvatarUrl = owner['avatar_url'] as String?;
+
+    final int? repoId = json['id'] as int?;
+    final String? repoName = json['name'] as String?;
+    final String? repoFullName = json['full_name'] as String?;
+    final String? repoHtmlUrl = json['html_url'] as String?;
+    final String? repoDescription = json['description'] as String?;
+
+    final String? repoLanguage = json['language'] as String?;
+    final int? startsCount = json['stargazers_count'] as int?;
+    final int? watchersCount = json['watchers_count'] as int?;
+    final int? forksCount = json['forks_count'] as int?;
+    final int? issuesCount = json['open_issues_count'] as int?;
+
+    final bool? isPrivate = json['private'] as bool?;
+    final bool? isArchived = json['archived'] as bool?;
+    final bool? isDisabled = json['disabled'] as bool?;
+
+    return RepoModel(
+      id: repoId ?? 0,
+      name: repoName ?? '',
+      fullName: repoFullName ?? '',
+      description: repoDescription ?? '',
+      htmlUrl: repoHtmlUrl ?? '',
+      ownerName: ownerName ?? '',
+      ownerAvatarUrl: ownerAvatarUrl ?? '',
+      language: repoLanguage ?? '',
+      startsCount: startsCount ?? 0,
+      watchersCount: watchersCount ?? 0,
+      forksCount: forksCount ?? 0,
+      issuesCount: issuesCount ?? 0,
+      isPrivate: isPrivate,
+      isArchived: isArchived,
+      isDisabled: isDisabled,
+    );
+  }
+
+  final int id;
+  final String name;
+  final String fullName;
+  final String htmlUrl;
+  final String description;
+
+  final String ownerName;
+  final String ownerAvatarUrl;
+
+  final String language;
+  final int startsCount;
+  final int watchersCount;
+  final int forksCount;
+  final int issuesCount;
+
+  final bool? isPrivate;
+  final bool? isArchived;
+  final bool? isDisabled;
+}

--- a/lib/domain/repository/searched_repo_repository.dart
+++ b/lib/domain/repository/searched_repo_repository.dart
@@ -1,0 +1,44 @@
+import 'package:dio/dio.dart';
+import 'package:search_repositories_on_github/domain/models/search_filers.dart';
+import 'package:search_repositories_on_github/domain/models/search_repositories_info_model.dart';
+import 'package:search_repositories_on_github/domain/rest_api/rest_api_service.dart';
+import 'package:search_repositories_on_github/foundation/debug/debug_logger.dart';
+
+class SearchedRepoRepository {
+  const SearchedRepoRepository(this._restApiService);
+  final RestApiService _restApiService;
+
+  Future<SearchRepoInfoModel> searchRepo({
+    required Query query,
+    required int page,
+  }) async {
+    try {
+      final Response<Map<String, dynamic>> response = await _restApiService.get(
+        path: 'https://api.github.com/search/repositories',
+        header: <String, String>{
+          'Accept': 'application/vnd.github+json',
+          // FIXME 時間があれば、トークン対応する。
+          // 'Authorization': 'Bearer $token',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+        queries: <String, dynamic>{
+          'q': query.toQueryStr(),
+          'sort': 'updated',
+          'order': 'desc',
+          'per_page': 20,
+          'page': page,
+        },
+      );
+      if (response.statusCode != null) {}
+      return SearchRepoInfoModel(
+        json: response.data!,
+        query: query.toQueryStr(),
+        parPage: 10,
+        page: page,
+      );
+    } on Exception catch (e) {
+      debugLog('debug - SearchedRepoRepository - Exception', cause: e);
+      rethrow;
+    }
+  }
+}

--- a/test/riverpod_counter_widget_test.dart
+++ b/test/riverpod_counter_widget_test.dart
@@ -58,7 +58,7 @@ void main() {
     await tester.pumpAndSettle(); //画面遷移が完了するまで待機
 
     final Finder secondCountFinder = find.byKey(secondPageCountKey);
-    Text secondCounterLabel =
+    final Text secondCounterLabel =
         secondCountFinder.evaluate().single.widget as Text;
 
     // Verify that our counter has incremented.


### PR DESCRIPTION
# プルリクエスト説明
## 目的
1. レスポンスモデルの再現でなく、要件必須項目のみ抜粋改変した。
  GitHub Search Repository API レスポンスは、巨大JSON構造だったため、
  要件に必要カ部分① のみ抜粋するように方針を変更した。
  この方針変更により、完全な JSONシリアライズ/デシリアライズをする意味がなくなったため、
  サーバからのレスポンスを確認しながら freezed や json_serializable を使うことなくモデルを作成した。

2. 検索条件フィルタクラスを作成した
  Search Repository API には複数の検索条件があるためフィルタクラスを追加した。
  ・InFilter:
  ・RangeFilter:
  ・Range:
  ・SingleMachFilter:
  ・DoubleMachFilter:
  ・BoolFilter:
  ・SingleFilter:

3. 検索フィルタをクエリアイテムとみなし、アイテムを総合してクエリを作成するようにした。
  - QueryItem: 検索フィルタのラッパーを兼ねたクエリアイテムを表すバリューオブジェクト
  - Query: 検索クエリクラス（検索フィルターのコンテナ）

4. 検索リポジトリを新規追加
  RestApiService を使って GitHub Search Repository API コール（RestApiService）を隠蔽し、
  検索結果データ取得のみの責務を果たすようにする。

①リポジトリ名、オーナーアイコン、プロジェクト言語、Star 数、Watcher 数、Fork 数、Issue 数

## 対応 ISSUE
Close #43

## 妥協点
JSON 構造の再現やシリアライズ/デシリアライズ相互変換の必要がなく、
JSON 構造を抜粋した改変モデルの作成となったため、freezed や json_serializable を利用しなかった。

## 課題
API レスポンス取得失敗時のリカバリ可能な例外のため、ユーザ通知のハンドリング追加が必要。

