### PR TITLE
インポート構成wo改良

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -25,7 +25,7 @@ linter:
     - always_put_control_body_on_new_line
     - always_put_required_named_parameters_first
     - always_specify_types
-    - always_use_package_imports
+    ##- always_use_package_imports
     - annotate_overrides
     - annotate_redeclares
     #- avoid_annotating_with_dynamic

--- a/lib/application/app_widget/app_widget.dart
+++ b/lib/application/app_widget/app_widget.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:search_repositories_on_github/application/l10n/gen/app_localizations.dart';
-import 'package:search_repositories_on_github/application/router/router.dart';
-import 'package:search_repositories_on_github/application/theme/theme.dart';
+
+import '../l10n/gen/app_localizations.dart';
+import '../router/router.dart';
+import '../theme/theme.dart';
 
 class App extends StatelessWidget {
   const App({super.key});

--- a/lib/application/error/app_error_handler.dart
+++ b/lib/application/error/app_error_handler.dart
@@ -7,11 +7,12 @@ import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
-import 'package:search_repositories_on_github/application/error/app_error_dialog.dart';
-import 'package:search_repositories_on_github/application/l10n/gen/app_localizations_ja.dart';
-import 'package:search_repositories_on_github/application/l10n/l10n_service.dart';
-import 'package:search_repositories_on_github/application/router/router.dart';
 import 'package:search_repositories_on_github/foundation/publications.dart';
+
+import '../error/app_error_dialog.dart';
+import '../l10n/gen/app_localizations_ja.dart';
+import '../l10n/l10n_service.dart';
+import '../router/router.dart';
 
 /// アプリレベルのエラーハンドラ設定クラス
 class AppErrorHandler {

--- a/lib/application/error/app_error_handler.dart
+++ b/lib/application/error/app_error_handler.dart
@@ -11,7 +11,7 @@ import 'package:search_repositories_on_github/application/error/app_error_dialog
 import 'package:search_repositories_on_github/application/l10n/gen/app_localizations_ja.dart';
 import 'package:search_repositories_on_github/application/l10n/l10n_service.dart';
 import 'package:search_repositories_on_github/application/router/router.dart';
-import 'package:search_repositories_on_github/foundation/debug/debug_logger.dart';
+import 'package:search_repositories_on_github/foundation/publications.dart';
 
 /// アプリレベルのエラーハンドラ設定クラス
 class AppErrorHandler {

--- a/lib/application/l10n/l10n_service.dart
+++ b/lib/application/l10n/l10n_service.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/widgets.dart';
-import 'package:search_repositories_on_github/application/l10n/gen/app_localizations.dart';
+
+import '../l10n/gen/app_localizations.dart';
 
 /// l10n 国際化メッセージ・リソースプロバイダ・サービス
 ///

--- a/lib/application/publications.dart
+++ b/lib/application/publications.dart
@@ -1,0 +1,14 @@
+// この publications.dart ファイルは、
+// application レイヤが外部に公開を許可するクラスや関数を限定させるためのものです。
+//
+// 1. 外部レイヤは、この publications.dart だけを import して、
+// 2. application/ ディレクトリ配下の他のライブラリを直接 import しないでください。
+//
+// この規約を守ることで、コンテキスト境界を超えた機能の誤用抑止に役立つだけでなく、
+// 各コードファイルの import 構成を一瞥することで、2 の誤用を簡単にチェックできます。
+//
+// 補足：application レイヤは、
+// flutterフレームワーク都合による、アプリ全体の共通基盤の管理を担うレイヤです。
+//
+export 'package:search_repositories_on_github/application/l10n/l10n_service.dart';
+export 'package:search_repositories_on_github/application/router/routes.dart';

--- a/lib/application/router/router.dart
+++ b/lib/application/router/router.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:search_repositories_on_github/application/router/routes.dart';
+
+import '../router/routes.dart';
 
 /// グローバルにアクセス可能な Navigator のキー
 ///

--- a/lib/application/router/routes.dart
+++ b/lib/application/router/routes.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:search_repositories_on_github/presentation/detail_page/page_widget/detail_page_widget.dart';
-import 'package:search_repositories_on_github/presentation/results_page/page_widget/result_page_widget.dart';
-import 'package:search_repositories_on_github/presentation/search_page/page_widget/search_page_widget.dart';
+import 'package:search_repositories_on_github/presentation/publications.dart';
 
 part 'routes.g.dart';
 

--- a/lib/domain/for_supervisors.dart
+++ b/lib/domain/for_supervisors.dart
@@ -1,0 +1,7 @@
+// この for_supervisors.dart ファイルは、
+// domain レイヤが特権管理者にのみ外部に公開を許可するクラスや関数を限定させるためのものです。
+//
+// 1. この for_supervisors.dart を import できるのは、
+//    アプリ全体の管理を担う application レイヤのアプリ全体初期化処理のみです。
+//
+export 'package:search_repositories_on_github/domain/rest_api/rest_api_service.dart';

--- a/lib/domain/models/search_repositories_info_model.dart
+++ b/lib/domain/models/search_repositories_info_model.dart
@@ -1,4 +1,4 @@
-import 'package:search_repositories_on_github/domain/models/searched_repository_model.dart';
+import './searched_repository_model.dart';
 
 /// リポジトリ検索モデル
 ///

--- a/lib/domain/publications.dart
+++ b/lib/domain/publications.dart
@@ -1,0 +1,16 @@
+// この publications.dart ファイルは、
+// domain レイヤが外部に公開を許可するクラスや関数を限定させるためのものです。
+//
+// 1. 外部レイヤは、この publications.dart だけを import して、
+// 2. domain/ ディレクトリ配下の他のライブラリを直接 import しないでください。
+//
+// この規約を守ることで、コンテキスト境界を超えた機能の誤用抑止に役立つだけでなく、
+// 各コードファイルの import 構成を一瞥することで、2 の誤用を簡単にチェックできます。
+//
+// 補足：domain レイヤは、
+// ユースケース都合に左右されない、アプリ内の共通基盤となるデータや機能の管理を担うレイヤです。
+//
+export 'package:search_repositories_on_github/domain/models/search_filers.dart';
+export 'package:search_repositories_on_github/domain/models/search_repositories_info_model.dart';
+export 'package:search_repositories_on_github/domain/models/searched_repository_model.dart';
+export 'package:search_repositories_on_github/domain/repository/searched_repo_repository.dart';

--- a/lib/domain/publications.dart
+++ b/lib/domain/publications.dart
@@ -10,7 +10,13 @@
 // 補足：domain レイヤは、
 // ユースケース都合に左右されない、アプリ内の共通基盤となるデータや機能の管理を担うレイヤです。
 //
+import 'package:search_repositories_on_github/domain/repository/searched_repo_repository.dart';
+
 export 'package:search_repositories_on_github/domain/models/search_filers.dart';
 export 'package:search_repositories_on_github/domain/models/search_repositories_info_model.dart';
 export 'package:search_repositories_on_github/domain/models/searched_repository_model.dart';
 export 'package:search_repositories_on_github/domain/repository/searched_repo_repository.dart';
+
+//FIXME AppWidgetを Hooks 対応して、アプリ初期化処理からインスタンス設定させること。
+/// クエリ検索結果データを提供するリポジトリのインスタンス
+late final SearchedRepoRepository searchedRepoRepositoryInstance;

--- a/lib/domain/repository/searched_repo_repository.dart
+++ b/lib/domain/repository/searched_repo_repository.dart
@@ -2,7 +2,7 @@ import 'package:dio/dio.dart';
 import 'package:search_repositories_on_github/domain/models/search_filers.dart';
 import 'package:search_repositories_on_github/domain/models/search_repositories_info_model.dart';
 import 'package:search_repositories_on_github/domain/rest_api/rest_api_service.dart';
-import 'package:search_repositories_on_github/foundation/debug/debug_logger.dart';
+import 'package:search_repositories_on_github/foundation/publications.dart';
 
 class SearchedRepoRepository {
   const SearchedRepoRepository(this._restApiService);

--- a/lib/domain/repository/searched_repo_repository.dart
+++ b/lib/domain/repository/searched_repo_repository.dart
@@ -1,8 +1,9 @@
 import 'package:dio/dio.dart';
-import 'package:search_repositories_on_github/domain/models/search_filers.dart';
-import 'package:search_repositories_on_github/domain/models/search_repositories_info_model.dart';
-import 'package:search_repositories_on_github/domain/rest_api/rest_api_service.dart';
 import 'package:search_repositories_on_github/foundation/publications.dart';
+
+import '../models/search_filers.dart';
+import '../models/search_repositories_info_model.dart';
+import '../rest_api/rest_api_service.dart';
 
 class SearchedRepoRepository {
   const SearchedRepoRepository(this._restApiService);

--- a/lib/domain/rest_api/rest_api_service.dart
+++ b/lib/domain/rest_api/rest_api_service.dart
@@ -1,7 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
-import 'package:search_repositories_on_github/foundation/debug/debug_logger.dart';
-import 'package:search_repositories_on_github/foundation/error/default_error.dart';
+import 'package:search_repositories_on_github/foundation/publications.dart';
 
 class RestApiService {
   RestApiService();

--- a/lib/foundation/publications.dart
+++ b/lib/foundation/publications.dart
@@ -1,0 +1,14 @@
+// この publications.dart ファイルは、
+// foundation レイヤが外部に公開を許可するクラスや関数を限定させるためのものです。
+//
+// 1. 外部レイヤは、この publications.dart だけを import して、
+// 2. foundation/ ディレクトリ 配下の他のライブラリを直接 import しないでください。
+//
+// この規約を守ることで、コンテキスト境界を超えた機能の誤用抑止に役立つだけでなく、
+// 各コードファイルの import 構成を一瞥することで、2 の誤用を簡単にチェックできます。
+//
+// 補足：foundation レイヤは、アプリ内で普遍的に利用される機能や基盤クラスの管理を担うレイヤです。
+//
+export 'package:search_repositories_on_github/foundation/debug/debug_logger.dart'
+    show debugLog;
+export 'package:search_repositories_on_github/foundation/error/default_error.dart';

--- a/lib/presentation/detail_page/page_widget/detail_page_widget.dart
+++ b/lib/presentation/detail_page/page_widget/detail_page_widget.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:search_repositories_on_github/presentation/search_page/page_widget/search_page_widget.dart';
+
+import '../../search_page/page_widget/search_page_widget.dart';
 
 class DetailPage extends ConsumerWidget {
   const DetailPage({super.key});

--- a/lib/presentation/publications.dart
+++ b/lib/presentation/publications.dart
@@ -1,0 +1,15 @@
+// この publications.dart ファイルは、
+// presentation レイヤが外部に公開を許可するクラスや関数を限定させるためのものです。
+//
+// 1. 外部レイヤは、この publications.dart だけを import して、
+// 2. presentation/ ディレクトリ配下の他のライブラリを直接 import しないでください。
+//
+// この規約を守ることで、コンテキスト境界を超えた機能の誤用抑止に役立つだけでなく、
+// 各コードファイルの import 構成を一瞥することで、2 の誤用を簡単にチェックできます。
+//
+// 補足：presentation レイヤは、
+// 画面表示やユースケース都合を優先させる、ユーザーインターフェースの管理を担うレイヤです。
+//
+export 'package:search_repositories_on_github/presentation/detail_page/page_widget/detail_page_widget.dart';
+export 'package:search_repositories_on_github/presentation/results_page/page_widget/result_page_widget.dart';
+export 'package:search_repositories_on_github/presentation/search_page/page_widget/search_page_widget.dart';

--- a/lib/presentation/results_page/page_widget/result_page_widget.dart
+++ b/lib/presentation/results_page/page_widget/result_page_widget.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:search_repositories_on_github/application/router/routes.dart';
 import 'package:search_repositories_on_github/presentation/search_page/page_widget/search_page_widget.dart';
+import 'package:search_repositories_on_github/use_case/publications.dart';
 
 class ResultsPage extends ConsumerWidget {
   const ResultsPage({super.key});

--- a/lib/presentation/results_page/page_widget/result_page_widget.dart
+++ b/lib/presentation/results_page/page_widget/result_page_widget.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:search_repositories_on_github/presentation/search_page/page_widget/search_page_widget.dart';
 import 'package:search_repositories_on_github/use_case/publications.dart';
+
+import '../../search_page/page_widget/search_page_widget.dart';
 
 class ResultsPage extends ConsumerWidget {
   const ResultsPage({super.key});

--- a/lib/presentation/results_page/page_widget/result_page_widget.dart
+++ b/lib/presentation/results_page/page_widget/result_page_widget.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:search_repositories_on_github/use_case/publications.dart';
+import 'package:search_repositories_on_github/application//publications.dart';
 
 import '../../search_page/page_widget/search_page_widget.dart';
 

--- a/lib/presentation/search_page/page_widget/search_page_widget.dart
+++ b/lib/presentation/search_page/page_widget/search_page_widget.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-import 'package:search_repositories_on_github/use_case/publications.dart';
+import 'package:search_repositories_on_github/application//publications.dart';
 
 part 'search_page_widget.g.dart';
 

--- a/lib/presentation/search_page/page_widget/search_page_widget.dart
+++ b/lib/presentation/search_page/page_widget/search_page_widget.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-import 'package:search_repositories_on_github/application/router/routes.dart';
+import 'package:search_repositories_on_github/use_case/publications.dart';
 
 part 'search_page_widget.g.dart';
 

--- a/lib/use_case/for_supervisors.dart
+++ b/lib/use_case/for_supervisors.dart
@@ -1,0 +1,6 @@
+// この for_supervisors.dart ファイルは、
+// use_case レイヤが特権管理者にのみ外部に公開を許可するクラスや関数を限定させるためのものです。
+//
+// 1. この for_supervisors.dart を import できるのは、
+//    アプリ全体の管理を担う application レイヤのアプリ全体初期化処理のみです。
+//

--- a/lib/use_case/publications.dart
+++ b/lib/use_case/publications.dart
@@ -10,4 +10,3 @@
 // 補足：use_case レイヤは、
 // ユースケース都合を優先させるため、domainレイヤをラップしたデータや機能の管理を担うレイヤです。
 //
-export 'package:search_repositories_on_github/application/router/routes.dart';

--- a/lib/use_case/publications.dart
+++ b/lib/use_case/publications.dart
@@ -1,0 +1,13 @@
+// この publications.dart ファイルは、
+// use_case レイヤが外部に公開を許可するクラスや関数を限定させるためのものです。
+//
+// 1. 外部レイヤは、この publications.dart だけを import して、
+// 2. use_case/ ディレクトリ配下の他のライブラリを直接 import しないでください。
+//
+// この規約を守ることで、コンテキスト境界を超えた機能の誤用抑止に役立つだけでなく、
+// 各コードファイルの import 構成を一瞥することで、2 の誤用を簡単にチェックできます。
+//
+// 補足：use_case レイヤは、
+// ユースケース都合を優先させるため、domainレイヤをラップしたデータや機能の管理を担うレイヤです。
+//
+export 'package:search_repositories_on_github/application/router/routes.dart';

--- a/test/freezed_json_unit_test.dart
+++ b/test/freezed_json_unit_test.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 
-import 'package:search_repositories_on_github/foundation/debug/debug_logger.dart';
+import 'package:search_repositories_on_github/foundation/publications.dart';
 import 'package:test/test.dart';
 
 import 'freezed/person.dart';

--- a/test/riverpod_counter_unit_test.dart
+++ b/test/riverpod_counter_unit_test.dart
@@ -1,5 +1,5 @@
 import 'package:riverpod/riverpod.dart';
-import 'package:search_repositories_on_github/foundation/debug/debug_logger.dart';
+import 'package:search_repositories_on_github/foundation/publications.dart';
 import 'package:test/test.dart';
 
 import 'riverpod_depend_app.dart';

--- a/test/riverpod_counter_widget_test.dart
+++ b/test/riverpod_counter_widget_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:search_repositories_on_github/foundation/debug/debug_logger.dart';
+import 'package:search_repositories_on_github/foundation/publications.dart';
 
 import 'riverpod_depend_app.dart';
 


### PR DESCRIPTION
# プルリクエスト説明
## 目的
アプリ機能の追加に伴い、レイヤをまたぐ連携により import 構成が肥大化し一瞥確認が困難になるため、
異なるレイヤ間での不要な import を避け、レイヤごとに公開機能を限定する仕組みを追加しました。

1. レイヤごとに機能公開ファイルを追加し、外部レイヤに提供する機能を限定
  レイヤ分けしたディレクトリのルートに **レイヤごとの機能公開ファイル `publications.dart`** を配置し、
  a. 外部レイヤでの import は、機能公開ファイルのみに限定するようにすることと、
  b. レイヤディレクトリ配下の他のライブラリを直接 import しないようにすることで、
  `エリック・エヴァンスのDDD` でのコンテキスト境界を越えた機能の誤用抑止に役立てるだけでなく、
  各コードファイルの import 構成を一瞥することで、b の誤用を簡単にチェックできるようにします。

2. レイヤごとに特権管理者専用の機能公開ファイルを追加し、外部レイヤに提供する機能を限定
  レイヤ分けしたルートに **レイヤごとの特権管理者用の機能公開ファイル `for_supervisors.dart`** を配置し、
  各レイヤが特権管理者にのみ許可するクラスや関数を限定させて公開することで、
  アプリ全体の管理を担う application レイヤでのアプリ全体初期化処理で扱えるようにします。
  _例：リポジトリやサービスの生成を行い、アプリ全体で共有するインスタンスを提供できるようにする。_

3. レイヤ内ファイルの import を相対パス指定に変更
  レイヤ分けしたディレクトリごとに、同一レイヤのファイル import を相対パス指定にしました。
  これは、外部レイヤ由来のパッケージ import との見分けが一瞥できるようにするためです。
  この方針のためパッケージ import を要請する、**`always_use_package_imports`** ルールを
  `analysis_options.yaml` からコメントアウトして除外させています。

## 対応 ISSUE
Close #45
- #45 

## 対応内容
_対応内容については、「目的」を参照_

## 妥協点
レイヤごとの機能公開ファイル `publications.dart` を無視して、外部レイヤのファイルの import は可能です。
これに対応するため、誤用 improt が目立つよう一瞥確認の向上を図っていますが開発者の自助努力が必要です。
対応策としては、マルチモジュール化がありますが、開発期間制約により今回のプロジェクトでは対応していません。
