### PR TITLE
国際化対応の残タスクを実装（リソース作成、ユースケース層対応）

### DIFF
--- a/lib/application/l10n/gen/app_localizations.dart
+++ b/lib/application/l10n/gen/app_localizations.dart
@@ -133,6 +133,144 @@ abstract class AppLocalizations {
   /// In ja, this message translates to:
   /// **'Cancel'**
   String get errorButtonCancel;
+
+  /// No description provided for @errorMessageEmptyQuery.
+  ///
+  /// In ja, this message translates to:
+  /// **'検索クエリがありません。'**
+  String get errorMessageEmptyQuery;
+
+  /// No description provided for @errorMessageTooLongQuery.
+  ///
+  /// In ja, this message translates to:
+  /// **'検索クエリは、256文字までです。'**
+  String get errorMessageTooLongQuery;
+
+  /// No description provided for @errorMessageDioException.
+  ///
+  /// In ja, this message translates to:
+  /// **'ネットワーク通信に問題がでました。'**
+  String get errorMessageDioException;
+
+  /// No description provided for @errorMessageUnknownException.
+  ///
+  /// In ja, this message translates to:
+  /// **'想定外の問題が発生しました。'**
+  String get errorMessageUnknownException;
+
+  /// No description provided for @errorMessageApiProblem.
+  ///
+  /// In ja, this message translates to:
+  /// **'サーバーとの間で問題が発生しました。'**
+  String get errorMessageApiProblem;
+
+  /// No description provided for @searchPageTitle.
+  ///
+  /// In ja, this message translates to:
+  /// **'GitHub リポジトリ検索'**
+  String get searchPageTitle;
+
+  /// No description provided for @searchRequest.
+  ///
+  /// In ja, this message translates to:
+  /// **'検索条件を指定してください。'**
+  String get searchRequest;
+
+  /// No description provided for @searchConditionReadme.
+  ///
+  /// In ja, this message translates to:
+  /// **'README 条件'**
+  String get searchConditionReadme;
+
+  /// No description provided for @searchConditionReadmeRequest.
+  ///
+  /// In ja, this message translates to:
+  /// **'README に含まれるテキストを入力してください'**
+  String get searchConditionReadmeRequest;
+
+  /// No description provided for @searchConditionDescription.
+  ///
+  /// In ja, this message translates to:
+  /// **'description 条件'**
+  String get searchConditionDescription;
+
+  /// No description provided for @searchConditionDescriptionRequest.
+  ///
+  /// In ja, this message translates to:
+  /// **'description に含まれるテキストを入力してください'**
+  String get searchConditionDescriptionRequest;
+
+  /// No description provided for @searchConditionRepoName.
+  ///
+  /// In ja, this message translates to:
+  /// **'リポジトリ名 条件'**
+  String get searchConditionRepoName;
+
+  /// No description provided for @searchConditionRepoNamRequest.
+  ///
+  /// In ja, this message translates to:
+  /// **'リポジトリ名 に含まれるテキストを入力してください'**
+  String get searchConditionRepoNamRequest;
+
+  /// No description provided for @searchConditionTopics.
+  ///
+  /// In ja, this message translates to:
+  /// **'topics 条件'**
+  String get searchConditionTopics;
+
+  /// No description provided for @searchConditionTopicsRequest.
+  ///
+  /// In ja, this message translates to:
+  /// **'topics のラベルを入力してください'**
+  String get searchConditionTopicsRequest;
+
+  /// No description provided for @searchButton.
+  ///
+  /// In ja, this message translates to:
+  /// **'検索'**
+  String get searchButton;
+
+  /// No description provided for @detailPageTitle.
+  ///
+  /// In ja, this message translates to:
+  /// **'GitHub リポジトリ検索'**
+  String get detailPageTitle;
+
+  /// No description provided for @detailItemRepoName.
+  ///
+  /// In ja, this message translates to:
+  /// **'リポジトリ名'**
+  String get detailItemRepoName;
+
+  /// No description provided for @detailItemOwnerIcon.
+  ///
+  /// In ja, this message translates to:
+  /// **'オーナーアイコン'**
+  String get detailItemOwnerIcon;
+
+  /// No description provided for @detailItemLanguage.
+  ///
+  /// In ja, this message translates to:
+  /// **'プロジェクト言語'**
+  String get detailItemLanguage;
+
+  /// No description provided for @detailItemStarCount.
+  ///
+  /// In ja, this message translates to:
+  /// **'Star 数'**
+  String get detailItemStarCount;
+
+  /// No description provided for @detailItemWatcherCount.
+  ///
+  /// In ja, this message translates to:
+  /// **'Watcher 数'**
+  String get detailItemWatcherCount;
+
+  /// No description provided for @detailItemIssueCount.
+  ///
+  /// In ja, this message translates to:
+  /// **'Issue 数'**
+  String get detailItemIssueCount;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/application/l10n/gen/app_localizations.dart
+++ b/lib/application/l10n/gen/app_localizations.dart
@@ -167,8 +167,14 @@ abstract class AppLocalizations {
   /// No description provided for @searchPageTitle.
   ///
   /// In ja, this message translates to:
-  /// **'GitHub リポジトリ検索'**
+  /// **'Search Page'**
   String get searchPageTitle;
+
+  /// No description provided for @searchPageSubTitle.
+  ///
+  /// In ja, this message translates to:
+  /// **'GitHub リポジトリ検索'**
+  String get searchPageSubTitle;
 
   /// No description provided for @searchRequest.
   ///
@@ -230,11 +236,29 @@ abstract class AppLocalizations {
   /// **'検索'**
   String get searchButton;
 
-  /// No description provided for @detailPageTitle.
+  /// No description provided for @resultsPageTitle.
+  ///
+  /// In ja, this message translates to:
+  /// **'Results Page'**
+  String get resultsPageTitle;
+
+  /// No description provided for @resultsPageSubTitle.
   ///
   /// In ja, this message translates to:
   /// **'GitHub リポジトリ検索'**
+  String get resultsPageSubTitle;
+
+  /// No description provided for @detailPageTitle.
+  ///
+  /// In ja, this message translates to:
+  /// **'Detail Page'**
   String get detailPageTitle;
+
+  /// No description provided for @detailPageSubTitle.
+  ///
+  /// In ja, this message translates to:
+  /// **'GitHub リポジトリ検索'**
+  String get detailPageSubTitle;
 
   /// No description provided for @detailItemRepoName.
   ///

--- a/lib/application/l10n/gen/app_localizations.dart
+++ b/lib/application/l10n/gen/app_localizations.dart
@@ -260,6 +260,12 @@ abstract class AppLocalizations {
   /// **'Star 数'**
   String get detailItemStarCount;
 
+  /// No description provided for @detailItemForkCount.
+  ///
+  /// In ja, this message translates to:
+  /// **'Fork 数'**
+  String get detailItemForkCount;
+
   /// No description provided for @detailItemWatcherCount.
   ///
   /// In ja, this message translates to:

--- a/lib/application/l10n/gen/app_localizations_en.dart
+++ b/lib/application/l10n/gen/app_localizations_en.dart
@@ -44,7 +44,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get errorMessageApiProblem => 'A problem occurred with the server.';
 
   @override
-  String get searchPageTitle => 'GitHub repository search';
+  String get searchPageTitle => 'Results Page';
+
+  @override
+  String get searchPageSubTitle => 'GitHub repository search';
 
   @override
   String get searchRequest => 'Please specify search conditions.';
@@ -80,7 +83,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String get searchButton => 'Search';
 
   @override
-  String get detailPageTitle => 'GitHub repository search';
+  String get resultsPageTitle => 'Results Page';
+
+  @override
+  String get resultsPageSubTitle => 'GitHub リポジトリ検索';
+
+  @override
+  String get detailPageTitle => 'Detail Page';
+
+  @override
+  String get detailPageSubTitle => 'GitHub repository search';
 
   @override
   String get detailItemRepoName => 'Repository name';

--- a/lib/application/l10n/gen/app_localizations_en.dart
+++ b/lib/application/l10n/gen/app_localizations_en.dart
@@ -95,6 +95,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get detailItemStarCount => 'Number of stars';
 
   @override
+  String get detailItemForkCount => 'Number of forks';
+
+  @override
   String get detailItemWatcherCount => 'Number of watchers';
 
   @override

--- a/lib/application/l10n/gen/app_localizations_en.dart
+++ b/lib/application/l10n/gen/app_localizations_en.dart
@@ -25,4 +25,78 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get errorButtonCancel => 'Cancel';
+
+  @override
+  String get errorMessageEmptyQuery => 'There is no search query.';
+
+  @override
+  String get errorMessageTooLongQuery =>
+      'Search queries cannot exceed 256 characters.';
+
+  @override
+  String get errorMessageDioException =>
+      'A network communication problem occurred.';
+
+  @override
+  String get errorMessageUnknownException => 'An unexpected problem occurred.';
+
+  @override
+  String get errorMessageApiProblem => 'A problem occurred with the server.';
+
+  @override
+  String get searchPageTitle => 'GitHub repository search';
+
+  @override
+  String get searchRequest => 'Please specify search conditions.';
+
+  @override
+  String get searchConditionReadme => 'README condition';
+
+  @override
+  String get searchConditionReadmeRequest =>
+      'Please enter text contained in README';
+
+  @override
+  String get searchConditionDescription => 'description condition';
+
+  @override
+  String get searchConditionDescriptionRequest =>
+      'Please enter text contained in description';
+
+  @override
+  String get searchConditionRepoName => 'Repository name condition';
+
+  @override
+  String get searchConditionRepoNamRequest =>
+      'Please enter text contained in repository name';
+
+  @override
+  String get searchConditionTopics => 'topics condition';
+
+  @override
+  String get searchConditionTopicsRequest => 'Enter topic label';
+
+  @override
+  String get searchButton => 'Search';
+
+  @override
+  String get detailPageTitle => 'GitHub repository search';
+
+  @override
+  String get detailItemRepoName => 'Repository name';
+
+  @override
+  String get detailItemOwnerIcon => 'Owner icon';
+
+  @override
+  String get detailItemLanguage => 'Project language';
+
+  @override
+  String get detailItemStarCount => 'Number of stars';
+
+  @override
+  String get detailItemWatcherCount => 'Number of watchers';
+
+  @override
+  String get detailItemIssueCount => 'Number of issues';
 }

--- a/lib/application/l10n/gen/app_localizations_ja.dart
+++ b/lib/application/l10n/gen/app_localizations_ja.dart
@@ -42,7 +42,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get errorMessageApiProblem => 'サーバーとの間で問題が発生しました。';
 
   @override
-  String get searchPageTitle => 'GitHub リポジトリ検索';
+  String get searchPageTitle => 'Search Page';
+
+  @override
+  String get searchPageSubTitle => 'GitHub リポジトリ検索';
 
   @override
   String get searchRequest => '検索条件を指定してください。';
@@ -76,7 +79,16 @@ class AppLocalizationsJa extends AppLocalizations {
   String get searchButton => '検索';
 
   @override
-  String get detailPageTitle => 'GitHub リポジトリ検索';
+  String get resultsPageTitle => 'Results Page';
+
+  @override
+  String get resultsPageSubTitle => 'GitHub リポジトリ検索';
+
+  @override
+  String get detailPageTitle => 'Detail Page';
+
+  @override
+  String get detailPageSubTitle => 'GitHub リポジトリ検索';
 
   @override
   String get detailItemRepoName => 'リポジトリ名';

--- a/lib/application/l10n/gen/app_localizations_ja.dart
+++ b/lib/application/l10n/gen/app_localizations_ja.dart
@@ -25,4 +25,74 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get errorButtonCancel => 'Cancel';
+
+  @override
+  String get errorMessageEmptyQuery => '検索クエリがありません。';
+
+  @override
+  String get errorMessageTooLongQuery => '検索クエリは、256文字までです。';
+
+  @override
+  String get errorMessageDioException => 'ネットワーク通信に問題がでました。';
+
+  @override
+  String get errorMessageUnknownException => '想定外の問題が発生しました。';
+
+  @override
+  String get errorMessageApiProblem => 'サーバーとの間で問題が発生しました。';
+
+  @override
+  String get searchPageTitle => 'GitHub リポジトリ検索';
+
+  @override
+  String get searchRequest => '検索条件を指定してください。';
+
+  @override
+  String get searchConditionReadme => 'README 条件';
+
+  @override
+  String get searchConditionReadmeRequest => 'README に含まれるテキストを入力してください';
+
+  @override
+  String get searchConditionDescription => 'description 条件';
+
+  @override
+  String get searchConditionDescriptionRequest =>
+      'description に含まれるテキストを入力してください';
+
+  @override
+  String get searchConditionRepoName => 'リポジトリ名 条件';
+
+  @override
+  String get searchConditionRepoNamRequest => 'リポジトリ名 に含まれるテキストを入力してください';
+
+  @override
+  String get searchConditionTopics => 'topics 条件';
+
+  @override
+  String get searchConditionTopicsRequest => 'topics のラベルを入力してください';
+
+  @override
+  String get searchButton => '検索';
+
+  @override
+  String get detailPageTitle => 'GitHub リポジトリ検索';
+
+  @override
+  String get detailItemRepoName => 'リポジトリ名';
+
+  @override
+  String get detailItemOwnerIcon => 'オーナーアイコン';
+
+  @override
+  String get detailItemLanguage => 'プロジェクト言語';
+
+  @override
+  String get detailItemStarCount => 'Star 数';
+
+  @override
+  String get detailItemWatcherCount => 'Watcher 数';
+
+  @override
+  String get detailItemIssueCount => 'Issue 数';
 }

--- a/lib/application/l10n/gen/app_localizations_ja.dart
+++ b/lib/application/l10n/gen/app_localizations_ja.dart
@@ -91,6 +91,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get detailItemStarCount => 'Star 数';
 
   @override
+  String get detailItemForkCount => 'Fork 数';
+
+  @override
   String get detailItemWatcherCount => 'Watcher 数';
 
   @override

--- a/lib/application/l10n/resource/app_en.arb
+++ b/lib/application/l10n/resource/app_en.arb
@@ -30,6 +30,7 @@
   "detailItemOwnerIcon" : "Owner icon",
   "detailItemLanguage" : "Project language",
   "detailItemStarCount" : "Number of stars",
+  "detailItemForkCount" : "Number of forks",
   "detailItemWatcherCount" : "Number of watchers",
   "detailItemIssueCount" : "Number of issues"
 }

--- a/lib/application/l10n/resource/app_en.arb
+++ b/lib/application/l10n/resource/app_en.arb
@@ -13,7 +13,8 @@
   "errorMessageUnknownException": "An unexpected problem occurred.",
   "errorMessageApiProblem": "A problem occurred with the server.",
 
-  "searchPageTitle": "GitHub repository search",
+  "searchPageTitle" : "Search Page",
+  "searchPageSubTitle": "GitHub repository search",
   "searchRequest": "Please specify search conditions.",
   "searchConditionReadme": "README condition",
   "searchConditionReadmeRequest": "Please enter text contained in README",
@@ -25,7 +26,11 @@
   "searchConditionTopicsRequest" : "Enter topic label",
   "searchButton" : "Search",
 
-  "detailPageTitle" : "GitHub repository search",
+  "searchPageTitle" : "Results Page",
+  "searchPageSubTitle": "GitHub repository search",
+
+  "detailPageTitle" : "Detail Page",
+  "detailPageSubTitle" : "GitHub repository search",
   "detailItemRepoName" : "Repository name",
   "detailItemOwnerIcon" : "Owner icon",
   "detailItemLanguage" : "Project language",

--- a/lib/application/l10n/resource/app_en.arb
+++ b/lib/application/l10n/resource/app_en.arb
@@ -5,5 +5,31 @@
   "errorDialogTitle": "Error",
   "errorDialogUnexpectedErrorMessage": "An unexpected error has occurred.\n\nWe are unable to fix the problem so please close the app.",
   "errorButtonOk": "OK",
-  "errorButtonCancel": "Cancel"
+  "errorButtonCancel": "Cancel",
+
+  "errorMessageEmptyQuery": "There is no search query.",
+  "errorMessageTooLongQuery": "Search queries cannot exceed 256 characters.",
+  "errorMessageDioException": "A network communication problem occurred.",
+  "errorMessageUnknownException": "An unexpected problem occurred.",
+  "errorMessageApiProblem": "A problem occurred with the server.",
+
+  "searchPageTitle": "GitHub repository search",
+  "searchRequest": "Please specify search conditions.",
+  "searchConditionReadme": "README condition",
+  "searchConditionReadmeRequest": "Please enter text contained in README",
+  "searchConditionDescription": "description condition",
+  "searchConditionDescriptionRequest": "Please enter text contained in description",
+  "searchConditionRepoName": "Repository name condition",
+  "searchConditionRepoNamRequest": "Please enter text contained in repository name",
+  "searchConditionTopics": "topics condition",
+  "searchConditionTopicsRequest" : "Enter topic label",
+  "searchButton" : "Search",
+
+  "detailPageTitle" : "GitHub repository search",
+  "detailItemRepoName" : "Repository name",
+  "detailItemOwnerIcon" : "Owner icon",
+  "detailItemLanguage" : "Project language",
+  "detailItemStarCount" : "Number of stars",
+  "detailItemWatcherCount" : "Number of watchers",
+  "detailItemIssueCount" : "Number of issues"
 }

--- a/lib/application/l10n/resource/app_ja.arb
+++ b/lib/application/l10n/resource/app_ja.arb
@@ -16,7 +16,8 @@
   "errorMessageUnknownException": "想定外の問題が発生しました。",
   "errorMessageApiProblem": "サーバーとの間で問題が発生しました。",
 
-  "searchPageTitle" : "GitHub リポジトリ検索",
+  "searchPageTitle" : "Search Page",
+  "searchPageSubTitle" : "GitHub リポジトリ検索",
   "searchRequest" : "検索条件を指定してください。",
   "searchConditionReadme" : "README 条件",
   "searchConditionReadmeRequest" : "README に含まれるテキストを入力してください",
@@ -28,7 +29,11 @@
   "searchConditionTopicsRequest" : "topics のラベルを入力してください",
   "searchButton" : "検索",
 
-  "detailPageTitle" : "GitHub リポジトリ検索",
+  "resultsPageTitle" : "Results Page",
+  "resultsPageSubTitle" : "GitHub リポジトリ検索",
+
+  "detailPageTitle" : "Detail Page",
+  "detailPageSubTitle" : "GitHub リポジトリ検索",
   "detailItemRepoName" : "リポジトリ名",
   "detailItemOwnerIcon" : "オーナーアイコン",
   "detailItemLanguage" : "プロジェクト言語",

--- a/lib/application/l10n/resource/app_ja.arb
+++ b/lib/application/l10n/resource/app_ja.arb
@@ -8,5 +8,31 @@
   "errorDialogTitle": "Error",
   "errorDialogUnexpectedErrorMessage": "想定外のエラーが発生しました。\n\n問題に対応できないため、アプリを終了してください。",
   "errorButtonOk": "OK",
-  "errorButtonCancel": "Cancel"
+  "errorButtonCancel": "Cancel",
+
+  "errorMessageEmptyQuery": "検索クエリがありません。",
+  "errorMessageTooLongQuery": "検索クエリは、256文字までです。",
+  "errorMessageDioException": "ネットワーク通信に問題がでました。",
+  "errorMessageUnknownException": "想定外の問題が発生しました。",
+  "errorMessageApiProblem": "サーバーとの間で問題が発生しました。",
+
+  "searchPageTitle" : "GitHub リポジトリ検索",
+  "searchRequest" : "検索条件を指定してください。",
+  "searchConditionReadme" : "README 条件",
+  "searchConditionReadmeRequest" : "README に含まれるテキストを入力してください",
+  "searchConditionDescription" : "description 条件",
+  "searchConditionDescriptionRequest" : "description に含まれるテキストを入力してください",
+  "searchConditionRepoName" : "リポジトリ名 条件",
+  "searchConditionRepoNamRequest" : "リポジトリ名 に含まれるテキストを入力してください",
+  "searchConditionTopics" : "topics 条件",
+  "searchConditionTopicsRequest" : "topics のラベルを入力してください",
+  "searchButton" : "検索",
+
+  "detailPageTitle" : "GitHub リポジトリ検索",
+  "detailItemRepoName" : "リポジトリ名",
+  "detailItemOwnerIcon" : "オーナーアイコン",
+  "detailItemLanguage" : "プロジェクト言語",
+  "detailItemStarCount" : "Star 数",
+  "detailItemWatcherCount" : "Watcher 数",
+  "detailItemIssueCount" : "Issue 数"
 }

--- a/lib/application/l10n/resource/app_ja.arb
+++ b/lib/application/l10n/resource/app_ja.arb
@@ -33,6 +33,7 @@
   "detailItemOwnerIcon" : "オーナーアイコン",
   "detailItemLanguage" : "プロジェクト言語",
   "detailItemStarCount" : "Star 数",
+  "detailItemForkCount" : "Fork 数",
   "detailItemWatcherCount" : "Watcher 数",
   "detailItemIssueCount" : "Issue 数"
 }

--- a/lib/domain/publications.dart
+++ b/lib/domain/publications.dart
@@ -12,6 +12,7 @@
 //
 import 'package:search_repositories_on_github/domain/repository/searched_repo_repository.dart';
 
+export 'package:search_repositories_on_github/domain/error/domain_exception.dart';
 export 'package:search_repositories_on_github/domain/models/search_filers.dart';
 export 'package:search_repositories_on_github/domain/models/search_repositories_info_model.dart';
 export 'package:search_repositories_on_github/domain/models/searched_repository_model.dart';

--- a/lib/presentation/detail_page/page_widget/detail_page_widget.dart
+++ b/lib/presentation/detail_page/page_widget/detail_page_widget.dart
@@ -30,7 +30,9 @@ class DetailPage extends HookConsumerWidget {
     final RepoModel repo = viewModel.getRepoInfo(index)!;
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Detail Page')),
+      appBar: AppBar(
+        title: Text(l10n(context).detailPageTitle),
+      ),
       body: SafeArea(
         top: true,
         bottom: true,
@@ -44,7 +46,7 @@ class DetailPage extends HookConsumerWidget {
                 child: Center(
                   child: Column(
                     children: <Widget>[
-                      SimpleText(l10n(context).detailPageTitle),
+                      SimpleText(l10n(context).detailPageSubTitle),
                       const Divider(),
                       ListTile(
                         title: SimpleText(l10n(context).detailItemRepoName),

--- a/lib/presentation/detail_page/page_widget/detail_page_widget.dart
+++ b/lib/presentation/detail_page/page_widget/detail_page_widget.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:search_repositories_on_github/application/publications.dart';
 import 'package:search_repositories_on_github/domain/publications.dart';
 
 import '../../ui_components/simple_text.dart';
@@ -43,26 +44,27 @@ class DetailPage extends HookConsumerWidget {
                 child: Center(
                   child: Column(
                     children: <Widget>[
-                      const SimpleText('GitHub リポジトリ検索'),
+                      SimpleText(l10n(context).detailPageTitle),
                       const Divider(),
                       ListTile(
-                        title: const SimpleText('リポジトリ名'),
+                        title: SimpleText(l10n(context).detailItemRepoName),
                         subtitle: SimpleText(repo.name, size: FontSize.medium),
                       ),
                       const Divider(),
+                      SimpleText(l10n(context).detailItemOwnerIcon),
                       FittedBox(
                         fit: BoxFit.contain,
                         child: Image.network(repo.ownerAvatarUrl),
                       ),
                       const Divider(),
                       ListTile(
-                        title: const SimpleText('プロジェクト言語'),
+                        title: SimpleText(l10n(context).detailItemLanguage),
                         subtitle:
                             SimpleText(repo.language, size: FontSize.medium),
                       ),
                       const Divider(),
                       ListTile(
-                        title: const SimpleText('Star 数'),
+                        title: SimpleText(l10n(context).detailItemStarCount),
                         subtitle: SimpleText(
                           repo.startsCount.toString(),
                           size: FontSize.medium,
@@ -70,7 +72,7 @@ class DetailPage extends HookConsumerWidget {
                       ),
                       const Divider(),
                       ListTile(
-                        title: const SimpleText('Watcher 数'),
+                        title: SimpleText(l10n(context).detailItemForkCount),
                         subtitle: SimpleText(
                           repo.watchersCount.toString(),
                           size: FontSize.medium,
@@ -78,7 +80,7 @@ class DetailPage extends HookConsumerWidget {
                       ),
                       const Divider(),
                       ListTile(
-                        title: const SimpleText('Fork 数'),
+                        title: SimpleText(l10n(context).detailItemWatcherCount),
                         subtitle: SimpleText(
                           repo.forksCount.toString(),
                           size: FontSize.medium,
@@ -86,7 +88,7 @@ class DetailPage extends HookConsumerWidget {
                       ),
                       const Divider(),
                       ListTile(
-                        title: const SimpleText('Issue 数'),
+                        title: SimpleText(l10n(context).detailItemIssueCount),
                         subtitle: SimpleText(
                           repo.issuesCount.toString(),
                           size: FontSize.medium,

--- a/lib/presentation/results_page/page_widget/results_page_widget.dart
+++ b/lib/presentation/results_page/page_widget/results_page_widget.dart
@@ -38,8 +38,8 @@ class ResultsPage extends HookConsumerWidget {
             right: true,
             child: CustomScrollView(
               slivers: <Widget>[
-                const SliverAppBar(
-                  title: Text('Results Page'),
+                SliverAppBar(
+                  title: Text(l10n(context).resultsPageTitle),
                 ),
                 SliverList(
                   delegate: SliverChildBuilderDelegate(

--- a/lib/presentation/results_page/page_widget/results_page_widget.dart
+++ b/lib/presentation/results_page/page_widget/results_page_widget.dart
@@ -44,7 +44,8 @@ class ResultsPage extends HookConsumerWidget {
                 SliverList(
                   delegate: SliverChildBuilderDelegate(
                     (BuildContext context, int index) {
-                      final RepoModel? repo = viewModel.getRepoInfo(index);
+                      final RepoModel? repo =
+                          viewModel.getRepoInfo(context, index);
                       return repo == null
                           ? null
                           : RepositoryCard(

--- a/lib/presentation/results_page/view_model/results_page_view_model.dart
+++ b/lib/presentation/results_page/view_model/results_page_view_model.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 // ignore: depend_on_referenced_packages
 import 'package:async/async.dart';
+import 'package:flutter/material.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:search_repositories_on_github/foundation/publications.dart';
 import 'package:search_repositories_on_github/use_case/publications.dart';
@@ -33,7 +34,7 @@ class ResultsPageViewModel extends _$ResultsPageViewModel {
   bool get isComplete => state.condition == Condition.complete;
 
   /// index 番号指定のリポジトリ情報を取得する。
-  RepoModel? getRepoInfo(int index) {
+  RepoModel? getRepoInfo(BuildContext context, int index) {
     final ({RepoModel? repo, int left}) res =
         searchRepoService.getRepoInfo(index);
     // データ未取得でかつ、取得可能であれば次ページデータを取得する。
@@ -41,18 +42,19 @@ class ResultsPageViewModel extends _$ResultsPageViewModel {
       // 次ページの検索を実行
       Future<void>.delayed(const Duration(milliseconds: 500), () {
         // ignore: discarded_futures
-        cacheStrategy.fetch(searchNext);
+        cacheStrategy.fetch(() => searchNext(context));
       });
     }
     return res.repo;
   }
 
   /// 指定クエリで次ページを検索
-  Future<void> searchNext() async {
+  Future<void> searchNext(BuildContext context) async {
     // 検索コンディションを 検索中に更新
     state = state.copyWith(condition: Condition.searching);
 
-    final SearchInfo? info = await searchRepoService.addNextRepositories();
+    final SearchInfo? info =
+        await searchRepoService.addNextRepositories(context: context);
     if (info != null) {
       // 検索コンディションを成功に更新
       state = state.copyWith(condition: Condition.complete);

--- a/lib/presentation/search_page/page_widget/search_page_widget.dart
+++ b/lib/presentation/search_page/page_widget/search_page_widget.dart
@@ -73,33 +73,38 @@ class SearchPageState extends State<SearchPage> {
                         child: Center(
                           child: Column(
                             children: <Widget>[
-                              const SimpleText('GitHub リポジトリ検索'),
-                              const SimpleText(
-                                '検索条件を指定してください。',
+                              SimpleText(l10n(context).searchPageTitle),
+                              SimpleText(
+                                l10n(context).searchRequest,
                                 size: FontSize.large,
                               ),
                               const SizedBox(height: 20),
-                              const SimpleText('README 条件'),
+                              SimpleText(l10n(context).searchConditionReadme),
                               SimpleTextField(
-                                labelText: 'README に含まれるテキストを入力してください',
+                                labelText:
+                                    l10n(context).searchConditionReadmeRequest,
                                 controller: _readmeController,
                               ),
                               const SizedBox(height: 20),
-                              const SimpleText('description 条件'),
+                              SimpleText(
+                                  l10n(context).searchConditionDescription),
                               SimpleTextField(
-                                labelText: 'description に含まれるテキストを入力してください',
+                                labelText: l10n(context)
+                                    .searchConditionDescriptionRequest,
                                 controller: _descriptionController,
                               ),
                               const SizedBox(height: 20),
-                              const SimpleText('リポジトリ名 条件'),
+                              SimpleText(l10n(context).searchConditionRepoName),
                               SimpleTextField(
-                                labelText: 'リポジトリ名 に含まれるテキストを入力してください',
+                                labelText:
+                                    l10n(context).searchConditionRepoNamRequest,
                                 controller: _repoNameController,
                               ),
                               const SizedBox(height: 20),
-                              const SimpleText('topics 条件'),
+                              SimpleText(l10n(context).searchConditionTopics),
                               SimpleTextField(
-                                labelText: 'topics のラベルを入力してください',
+                                labelText:
+                                    l10n(context).searchConditionTopicsRequest,
                                 controller: _topicsController,
                               ),
                             ],
@@ -111,7 +116,7 @@ class SearchPageState extends State<SearchPage> {
                     Padding(
                       padding: const EdgeInsets.all(16),
                       child: SimpleButton(
-                        label: '検索',
+                        label: l10n(context).searchButton,
                         onPressed: (BuildContext context) async {
                           await viewModel.search(
                             context: context,

--- a/lib/presentation/search_page/page_widget/search_page_widget.dart
+++ b/lib/presentation/search_page/page_widget/search_page_widget.dart
@@ -114,6 +114,7 @@ class SearchPageState extends State<SearchPage> {
                         label: '検索',
                         onPressed: (BuildContext context) async {
                           await viewModel.search(
+                            context: context,
                             readme: _readmeController.text,
                             description: _descriptionController.text,
                             repoName: _repoNameController.text,

--- a/lib/presentation/search_page/page_widget/search_page_widget.dart
+++ b/lib/presentation/search_page/page_widget/search_page_widget.dart
@@ -73,7 +73,7 @@ class SearchPageState extends State<SearchPage> {
                         child: Center(
                           child: Column(
                             children: <Widget>[
-                              SimpleText(l10n(context).searchPageTitle),
+                              SimpleText(l10n(context).searchPageSubTitle),
                               SimpleText(
                                 l10n(context).searchRequest,
                                 size: FontSize.large,

--- a/lib/presentation/search_page/view_model/search_page_view_model.dart
+++ b/lib/presentation/search_page/view_model/search_page_view_model.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:search_repositories_on_github/foundation/publications.dart';
 import 'package:search_repositories_on_github/use_case/publications.dart';
@@ -27,6 +28,7 @@ class SearchPageViewModel extends _$SearchPageViewModel {
 
   /// 指定クエリでリポジトリを検索
   Future<void> search({
+    required BuildContext context,
     required String readme,
     required String description,
     required String repoName,
@@ -36,6 +38,7 @@ class SearchPageViewModel extends _$SearchPageViewModel {
     state = state.copyWith(condition: Condition.searching);
 
     final SearchInfo? info = await searchRepoService.searchRepoByInQuery(
+      context: context,
       readme: readme,
       description: description,
       repoName: repoName,

--- a/lib/use_case/service/search_repo_info_service.dart
+++ b/lib/use_case/service/search_repo_info_service.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
-import 'package:search_repositories_on_github/application/router/router.dart';
-import 'package:search_repositories_on_github/domain/error/domain_exception.dart';
+import 'package:flutter/material.dart';
+import 'package:search_repositories_on_github/application/publications.dart';
 import 'package:search_repositories_on_github/domain/publications.dart';
 import 'package:search_repositories_on_github/foundation/publications.dart';
 
@@ -45,6 +45,7 @@ class SearchRepoService {
   /// この API が利用されるユースケースとしては、
   /// 検索条件を入力して検索ボタンを押下したときを想定しています。
   Future<SearchInfo?> searchRepoByInQuery({
+    required BuildContext context,
     required String readme,
     required String description,
     required String repoName,
@@ -82,19 +83,22 @@ class SearchRepoService {
         'SearchRepoService - searchRepoByInQuery catch Exception.',
         cause: exp,
       );
-      final String message = switch (exp.type) {
-        DomainExceptionType.emptyQuery => '検索クエリがありません。',
-        DomainExceptionType.tooLongQuery => '検索クエリは、256文字までです。',
-        DomainExceptionType.dioException => 'ネットワーク通信に問題がでました。',
-        DomainExceptionType.unknownException => '想定外の問題が発生しました。',
-        _ => 'サーバーとの間で問題が発生しました。',
-      };
-
-      if (globalNavigatorContext.mounted) {
+      if (context.mounted) {
+        final String message = switch (exp.type) {
+          DomainExceptionType.emptyQuery =>
+            l10n(context).errorMessageEmptyQuery,
+          DomainExceptionType.tooLongQuery =>
+            l10n(context).errorMessageTooLongQuery,
+          DomainExceptionType.dioException =>
+            l10n(context).errorMessageDioException,
+          DomainExceptionType.unknownException =>
+            l10n(context).errorMessageUnknownException,
+          _ => l10n(context).errorMessageApiProblem,
+        };
         unawaited(
           _errorDialog.showErrorAlertDialog(
-            context: globalNavigatorContext,
-            title: 'Error',
+            context: context,
+            title: l10n(context).errorDialogTitle,
             message: message,
           ),
         );
@@ -109,7 +113,9 @@ class SearchRepoService {
   /// 検索結果一覧のスクロールで下端に達したときを想定しています。
   ///
   /// _返却された検索情報には、今まで取得したページ分の情報も含まれています。_
-  Future<SearchInfo?> addNextRepositories() async {
+  Future<SearchInfo?> addNextRepositories({
+    required BuildContext context,
+  }) async {
     try {
       // リポジトリに問い合わせ
       final SearchRepoInfoModel info = await _repository.addNextRepositories();
@@ -125,19 +131,23 @@ class SearchRepoService {
         'SearchRepoService - addNextRepositories catch Exception.',
         cause: exp,
       );
-      final String message = switch (exp.type) {
-        DomainExceptionType.emptyQuery => '検索クエリがありません。',
-        DomainExceptionType.tooLongQuery => '検索クエリは、256文字までです。',
-        DomainExceptionType.dioException => 'ネットワーク通信に問題がでました。',
-        DomainExceptionType.unknownException => '想定外の問題が発生しました。',
-        _ => 'サーバーとの間で問題が発生しました。',
-      };
 
-      if (globalNavigatorContext.mounted) {
+      if (context.mounted) {
+        final String message = switch (exp.type) {
+          DomainExceptionType.emptyQuery =>
+            l10n(context).errorMessageEmptyQuery,
+          DomainExceptionType.tooLongQuery =>
+            l10n(context).errorMessageTooLongQuery,
+          DomainExceptionType.dioException =>
+            l10n(context).errorMessageDioException,
+          DomainExceptionType.unknownException =>
+            l10n(context).errorMessageUnknownException,
+          _ => l10n(context).errorMessageApiProblem,
+        };
         unawaited(
           _errorDialog.showErrorAlertDialog(
-            context: globalNavigatorContext,
-            title: 'Error',
+            context: context,
+            title: l10n(context).errorDialogTitle,
             message: message,
           ),
         );


### PR DESCRIPTION
# プルリクエスト説明
## 目的
国際化対応のリソースを追加して、実装優先で後回しになっていた、
プレゼンテーション層とユースケース層の国際化対応です。

## 対応 ISSUE
Close #50

## 対応内容
- SearchPage, ResultsPage, DetailPage の国際化リソースを追加
- エラー文言の国際化対応メッセージ追加
- ユースケース層の国際化対応（メソッド・パラメータに context必須化）

## テスト
- 日本語環境
<img width="561" alt="スクリーンショット 2025-01-12 9 41 09" src="https://github.com/user-attachments/assets/936edb10-7267-48be-ad58-2a24b8263c9d" />

- 英語環境
<img width="561" alt="スクリーンショット 2025-01-12 9 42 42" src="https://github.com/user-attachments/assets/115255d3-c20d-4bcc-8b3e-720afb3f6d5d" />


