### PR TITLE
検索レート超過時の対応を修正（エラーダイアログが複数件表示されないよう修正）

### DIFF
--- a/lib/application/l10n/gen/app_localizations.dart
+++ b/lib/application/l10n/gen/app_localizations.dart
@@ -152,6 +152,12 @@ abstract class AppLocalizations {
   /// **'ネットワーク通信に問題がでました。'**
   String get errorMessageDioException;
 
+  /// No description provided for @errorMessageOverRateLimits.
+  ///
+  /// In ja, this message translates to:
+  /// **'検索レート制限を越えました、しばらく利用を控えてください。'**
+  String get errorMessageOverRateLimits;
+
   /// No description provided for @errorMessageUnknownException.
   ///
   /// In ja, this message translates to:

--- a/lib/application/l10n/gen/app_localizations_en.dart
+++ b/lib/application/l10n/gen/app_localizations_en.dart
@@ -38,6 +38,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'A network communication problem occurred.';
 
   @override
+  String get errorMessageOverRateLimits =>
+      'You have exceeded search rate limit.\nPlease refrain from using for a while.';
+
+  @override
   String get errorMessageUnknownException => 'An unexpected problem occurred.';
 
   @override

--- a/lib/application/l10n/gen/app_localizations_ja.dart
+++ b/lib/application/l10n/gen/app_localizations_ja.dart
@@ -36,6 +36,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get errorMessageDioException => 'ネットワーク通信に問題がでました。';
 
   @override
+  String get errorMessageOverRateLimits => '検索レート制限を越えました、しばらく利用を控えてください。';
+
+  @override
   String get errorMessageUnknownException => '想定外の問題が発生しました。';
 
   @override

--- a/lib/application/l10n/resource/app_en.arb
+++ b/lib/application/l10n/resource/app_en.arb
@@ -10,6 +10,7 @@
   "errorMessageEmptyQuery": "There is no search query.",
   "errorMessageTooLongQuery": "Search queries cannot exceed 256 characters.",
   "errorMessageDioException": "A network communication problem occurred.",
+  "errorMessageOverRateLimits": "You have exceeded search rate limit.\nPlease refrain from using for a while.",
   "errorMessageUnknownException": "An unexpected problem occurred.",
   "errorMessageApiProblem": "A problem occurred with the server.",
 

--- a/lib/application/l10n/resource/app_ja.arb
+++ b/lib/application/l10n/resource/app_ja.arb
@@ -13,6 +13,7 @@
   "errorMessageEmptyQuery": "検索クエリがありません。",
   "errorMessageTooLongQuery": "検索クエリは、256文字までです。",
   "errorMessageDioException": "ネットワーク通信に問題がでました。",
+  "errorMessageOverRateLimits": "検索レート制限を越えました、しばらく利用を控えてください。",
   "errorMessageUnknownException": "想定外の問題が発生しました。",
   "errorMessageApiProblem": "サーバーとの間で問題が発生しました。",
 

--- a/lib/domain/error/domain_exception.dart
+++ b/lib/domain/error/domain_exception.dart
@@ -17,6 +17,7 @@ enum DomainExceptionType {
   // ignore: avoid_escaping_inner_quotes
   notMatchQuery('Search query doesn\'t match previous.'),
   dioException('Dio Exceptions.'),
+  overRateLimits('403|429: over rate limits.'),
   notModified('304: Not modified.'),
   validationFailed('422: Validation failed, or the endpoint has been spammed.'),
   apiServerError('503: Service unavailable.'),

--- a/lib/domain/repository/searched_repo_repository.dart
+++ b/lib/domain/repository/searched_repo_repository.dart
@@ -116,6 +116,17 @@ class SearchedRepoRepository {
         cause: e,
       );
       if (e is DioException) {
+        if (e.response?.statusCode == 403 || e.response?.statusCode == 429) {
+          // Rate limits for the REST API
+          // https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#exceeding-the-rate-limit
+          // プライマリ レート制限を超えると、403 または 429 が返されます。
+          // 指定された時間が経過するまで、リクエストを再試行しないでください。
+          throw DomainException(
+            '',
+            type: DomainExceptionType.overRateLimits,
+            option: e,
+          );
+        }
         throw DomainException(
           '',
           type: DomainExceptionType.dioException,
@@ -130,7 +141,7 @@ class SearchedRepoRepository {
 
   /// HTTP Status Code error check
   void _checkError(int? code) {
-    if (code != null) {
+    if (code == null) {
       return;
     }
 

--- a/lib/domain/rest_api/rest_api_service.dart
+++ b/lib/domain/rest_api/rest_api_service.dart
@@ -39,12 +39,14 @@ class RestApiService {
       // タイムアウト
       if (exception.type == DioExceptionType.connectionTimeout ||
           exception.type == DioExceptionType.sendTimeout ||
-          exception.type == DioExceptionType.receiveTimeout) {}
-      throw DomainException(
-        '',
-        type: DomainExceptionType.dioException,
-        cause: exception,
-      );
+          exception.type == DioExceptionType.receiveTimeout) {
+        throw DomainException(
+          '',
+          type: DomainExceptionType.dioException,
+          cause: exception,
+        );
+      }
+      rethrow;
     }
   }
 

--- a/lib/use_case/service/search_repo_info_service.dart
+++ b/lib/use_case/service/search_repo_info_service.dart
@@ -10,6 +10,7 @@ import '../error/use_case_error_dialog.dart';
 /// ユースケース・レイヤレベルの検索情報を取得します。
 class SearchRepoService {
   SearchRepoService(this._repository);
+
   final SearchedRepoRepository _repository;
   final UseCaseErrorHDialog _errorDialog = UseCaseErrorHDialog();
 
@@ -150,12 +151,10 @@ class SearchRepoService {
             l10n(context).errorMessageUnknownException,
           _ => l10n(context).errorMessageApiProblem,
         };
-        unawaited(
-          _errorDialog.showErrorAlertDialog(
-            context: context,
-            title: l10n(context).errorDialogTitle,
-            message: message,
-          ),
+        await _errorDialog.showErrorAlertDialog(
+          context: context,
+          title: l10n(context).errorDialogTitle,
+          message: message,
         );
       }
     }

--- a/lib/use_case/service/search_repo_info_service.dart
+++ b/lib/use_case/service/search_repo_info_service.dart
@@ -10,7 +10,6 @@ import '../error/use_case_error_dialog.dart';
 /// ユースケース・レイヤレベルの検索情報を取得します。
 class SearchRepoService {
   SearchRepoService(this._repository);
-
   final SearchedRepoRepository _repository;
   final UseCaseErrorHDialog _errorDialog = UseCaseErrorHDialog();
 
@@ -145,6 +144,8 @@ class SearchRepoService {
             l10n(context).errorMessageEmptyQuery,
           DomainExceptionType.tooLongQuery =>
             l10n(context).errorMessageTooLongQuery,
+          DomainExceptionType.overRateLimits =>
+            l10n(context).errorMessageOverRateLimits,
           DomainExceptionType.dioException =>
             l10n(context).errorMessageDioException,
           DomainExceptionType.unknownException =>


### PR DESCRIPTION
# プルリクエスト説明
## 目的
エラーダイアログ表示を `OK` ボタンタップで閉じるまで、処理を止めるよう修正。

_短期間に大量の REST API を発行すると REST API rate limits に抵触し、
抵触による制限期間中の API 実行は、常に 403 エラーになるため、
無限スクロールの末尾で Next Search が連続して発行されないようにする。_


## 対応 ISSUE
Close #63


## 対応内容
- `DomainException` に `overRateLimits` を新規追加

- overRateLimits 例外の国際化対応メッセージ・リソースを追加

- エラーダイアログ表示中は、処理を止めるように修正
- 対応前（unawaited により、エラーダイアログ表示中も処理を止めないようにしている）
```dart
        unawaited(
          _errorDialog.showErrorAlertDialog(
            context: context,
            title: l10n(context).errorDialogTitle,
            message: message,
          ),
```

- 対応後（エラーダイアログが閉じるまで、処理を止めるように修正）
```dart
        await _errorDialog.showErrorAlertDialog(
          context: context,
          title: l10n(context).errorDialogTitle,
          message: message,
        );
```


## テスト
- 無限スクロールで REST API rate limits が発生しても、エラーダイアログは複数件表示されない。
  - エラーメッセージが、検索レート超過に修正されている。

![検索レート超過エラーが単一表示される](https://github.com/user-attachments/assets/5cc5c0d2-2a56-4f5e-ba5d-5b80e467aef5)

