### PR TITLE
AppBarを固定表示かつ背景色とスクロール色を同一色に指定

### DIFF
--- a/lib/presentation/results_page/page_widget/results_page_widget.dart
+++ b/lib/presentation/results_page/page_widget/results_page_widget.dart
@@ -40,6 +40,9 @@ class ResultsPage extends HookConsumerWidget {
               slivers: <Widget>[
                 SliverAppBar(
                   title: Text(l10n(context).resultsPageTitle),
+                  pinned: true,
+                  backgroundColor: Theme.of(context).colorScheme.surface,
+                  surfaceTintColor: Theme.of(context).colorScheme.surface,
                 ),
                 SliverList(
                   delegate: SliverChildBuilderDelegate(


### PR DESCRIPTION
# プルリクエスト説明
## 目的
検索画面でスクロールさせても App Bar 表示を残すようにしました。

_App Bar を隠すとスワイプ操作で前画面に戻るジェスチャーを知らない人には、
前画面に戻るためにスクロールを最初に戻して App Bar 表示させる必要があるため。_


## 対応 ISSUE
Close #65


## 対応内容
- SliverAppBar プロパティで AppBar 固定表示  
  _スクロールさせても色が変わらないよう背景色とスクロール重色に同色を指定_
  - pinned: true,
  -  backgroundColor: Theme.of(context).colorScheme.surface,
  - surfaceTintColor: Theme.of(context).colorScheme.surface,
- SliverAppBar class
  https://api.flutter.dev/flutter/material/SliverAppBar-class.html


## テスト
- 修正後動画
![検索一覧画面_AppBar固定表示](https://github.com/user-attachments/assets/768045e0-258e-4ba1-976c-ddc647d0be18)

