### PR TITLE
SearchPageは、縦方向画面のみに制限する。

### DIFF
--- a/lib/presentation/detail_page/page_widget/detail_page_widget.dart
+++ b/lib/presentation/detail_page/page_widget/detail_page_widget.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:search_repositories_on_github/application/publications.dart';
@@ -13,10 +16,28 @@ class DetailPage extends HookConsumerWidget {
   final int index;
 
   Dispose? _initState() {
+    // 画面方向指定解除（全方向指定）
+    unawaited(
+      SystemChrome.setPreferredOrientations(<DeviceOrientation>[
+        DeviceOrientation.portraitUp,
+        DeviceOrientation.portraitDown,
+        DeviceOrientation.landscapeLeft,
+        DeviceOrientation.landscapeRight,
+      ]),
+    );
     return _dispose;
   }
 
   Dispose? _dispose() {
+    // 画面方向指定解除（全方向指定）
+    unawaited(
+      SystemChrome.setPreferredOrientations(<DeviceOrientation>[
+        DeviceOrientation.portraitUp,
+        DeviceOrientation.portraitDown,
+        DeviceOrientation.landscapeLeft,
+        DeviceOrientation.landscapeRight,
+      ]),
+    );
     return null;
   }
 

--- a/lib/presentation/results_page/page_widget/results_page_widget.dart
+++ b/lib/presentation/results_page/page_widget/results_page_widget.dart
@@ -59,8 +59,6 @@ class ResultsPage extends HookConsumerWidget {
                 SliverAppBar(
                   title: Text(l10n(context).resultsPageTitle),
                   pinned: true,
-                  backgroundColor: Theme.of(context).colorScheme.surface,
-                  surfaceTintColor: Theme.of(context).colorScheme.surface,
                 ),
                 SliverList(
                   delegate: SliverChildBuilderDelegate(

--- a/lib/presentation/results_page/page_widget/results_page_widget.dart
+++ b/lib/presentation/results_page/page_widget/results_page_widget.dart
@@ -1,4 +1,7 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:search_repositories_on_github/application/publications.dart';
@@ -13,10 +16,25 @@ class ResultsPage extends HookConsumerWidget {
   const ResultsPage({super.key});
 
   Dispose? _initState() {
+    // 画面方向指定解除（全方向指定）
+    unawaited(
+      SystemChrome.setPreferredOrientations(<DeviceOrientation>[
+        DeviceOrientation.portraitUp,
+        DeviceOrientation.portraitDown,
+        DeviceOrientation.landscapeLeft,
+        DeviceOrientation.landscapeRight,
+      ]),
+    );
     return _dispose;
   }
 
   Dispose? _dispose() {
+    // 画面方向を（縦方向のみ）に指定
+    unawaited(
+      SystemChrome.setPreferredOrientations(<DeviceOrientation>[
+        DeviceOrientation.portraitUp,
+      ]),
+    );
     return null;
   }
 

--- a/lib/presentation/search_page/page_widget/search_page_widget.dart
+++ b/lib/presentation/search_page/page_widget/search_page_widget.dart
@@ -1,4 +1,7 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:search_repositories_on_github/application/publications.dart';
 import 'package:search_repositories_on_github/foundation/publications.dart';
@@ -37,7 +40,29 @@ class SearchPageState extends State<SearchPage> {
   }
 
   @override
+  void didChangeDependencies() {
+    // 狭小画面デバイス及び、ソフトキーボード高が大きいものがあるため、
+    // 画面方向を（縦方向のみ）に指定
+    unawaited(
+      SystemChrome.setPreferredOrientations([
+        DeviceOrientation.portraitUp,
+      ]),
+    );
+    super.didChangeDependencies();
+  }
+
+  @override
   void dispose() {
+    // 画面方向指定解除（全方向指定）
+    unawaited(
+      SystemChrome.setPreferredOrientations([
+        DeviceOrientation.portraitUp,
+        DeviceOrientation.portraitDown,
+        DeviceOrientation.landscapeLeft,
+        DeviceOrientation.landscapeRight,
+      ]),
+    );
+
     _readmeController.dispose();
     _descriptionController.dispose();
     _repoNameController.dispose();

--- a/lib/presentation/search_page/page_widget/search_page_widget.dart
+++ b/lib/presentation/search_page/page_widget/search_page_widget.dart
@@ -44,7 +44,7 @@ class SearchPageState extends State<SearchPage> {
     // 狭小画面デバイス及び、ソフトキーボード高が大きいものがあるため、
     // 画面方向を（縦方向のみ）に指定
     unawaited(
-      SystemChrome.setPreferredOrientations([
+      SystemChrome.setPreferredOrientations(<DeviceOrientation>[
         DeviceOrientation.portraitUp,
       ]),
     );
@@ -55,7 +55,7 @@ class SearchPageState extends State<SearchPage> {
   void dispose() {
     // 画面方向指定解除（全方向指定）
     unawaited(
-      SystemChrome.setPreferredOrientations([
+      SystemChrome.setPreferredOrientations(<DeviceOrientation>[
         DeviceOrientation.portraitUp,
         DeviceOrientation.portraitDown,
         DeviceOrientation.landscapeLeft,


### PR DESCRIPTION
# プルリクエスト説明
## 目的
狭小画面デバイスやソフトウェアキーボードが大きい場合、
検索ボタンと検索条件が表示できなくなるため SearchPage のみ Portrait 表示に制限します。

## 対応 ISSUE
Close #67


## 対応内容
SearchPage のみ portrait 表示に制限した。
ResultsPage や DetailPage は、在来通り portrait / Landscape 対応とした。

## テスト
- SearchPage 
<img width="494" alt="スクリーンショット 2025-01-22 18 51 34" src="https://github.com/user-attachments/assets/f264351b-4d3a-42d5-82d4-5e647632a78c" />

<img width="810" alt="スクリーンショット 2025-01-22 18 51 42" src="https://github.com/user-attachments/assets/67bf7b1c-9574-422f-a270-8d9f8fc53396" />

- ResultsPage 
<img width="498" alt="スクリーンショット 2025-01-22 18 52 36" src="https://github.com/user-attachments/assets/edd11aa6-9c42-411b-8405-26e311bff7b0" />

<img width="824" alt="スクリーンショット 2025-01-22 18 52 45" src="https://github.com/user-attachments/assets/6d2b2eb4-3280-4a16-889b-1aae8399a89e" />

- DetailPage
<img width="494" alt="スクリーンショット 2025-01-22 18 53 25" src="https://github.com/user-attachments/assets/d65882d1-7e0f-4954-9c79-81fd294f53f4" />

<img width="810" alt="スクリーンショット 2025-01-22 18 53 37" src="https://github.com/user-attachments/assets/309787cc-3250-472c-8a5f-315782742358" />


### iPad では、SearchPage の画面縦方向指定はありません。
ですが iPad は、狭小画面デバイスではないので問題ないとします。

<img width="814" alt="スクリーンショット 2025-01-22 19 08 30" src="https://github.com/user-attachments/assets/d725ef29-6228-4854-af82-982e28b4b294" />

<img width="1076" alt="スクリーンショット 2025-01-22 19 08 36" src="https://github.com/user-attachments/assets/c574442a-e288-419e-87c5-abd6cea07e54" />


