### PR TITLE
（Android プラットフォーム固有問題）無限スクロールのスクロール位置を補正するよう修正。

### DIFF
--- a/lib/application/router/routes.dart
+++ b/lib/application/router/routes.dart
@@ -29,7 +29,7 @@ class SearchPageRoute extends GoRouteData {
 class ResultsPageRoute extends GoRouteData {
   @override
   Widget build(BuildContext context, GoRouterState state) {
-    return const ResultsPage();
+    return ResultsPage();
   }
 }
 

--- a/lib/presentation/results_page/page_widget/results_page_widget.dart
+++ b/lib/presentation/results_page/page_widget/results_page_widget.dart
@@ -13,7 +13,9 @@ import '../../ui_components/repository_card.dart';
 import '../view_model/results_page_view_model.dart';
 
 class ResultsPage extends HookConsumerWidget {
-  const ResultsPage({super.key});
+  ResultsPage({super.key});
+
+  final ScrollController _scrollController = ScrollController();
 
   Dispose? _initState() {
     // 画面方向指定解除（全方向指定）
@@ -35,13 +37,14 @@ class ResultsPage extends HookConsumerWidget {
         DeviceOrientation.portraitUp,
       ]),
     );
+    _scrollController.dispose();
     return null;
   }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     debugLog('debug - ResultsPage - build');
-    useEffect(_initState, <Object?>[]);
+    useEffect(_initState, <Object?>[_scrollController]);
 
     final ResultsPageViewModel viewModel =
         ref.read(resultsPageViewModelProvider.notifier);
@@ -55,6 +58,7 @@ class ResultsPage extends HookConsumerWidget {
             left: true,
             right: true,
             child: CustomScrollView(
+              controller: _scrollController,
               slivers: <Widget>[
                 SliverAppBar(
                   title: Text(l10n(context).resultsPageTitle),
@@ -63,13 +67,13 @@ class ResultsPage extends HookConsumerWidget {
                 SliverList(
                   delegate: SliverChildBuilderDelegate(
                     (BuildContext context, int index) {
-                      final RepoModel? repo =
-                          viewModel.getRepoInfo(context, index);
+                      final RepoModel? repo = viewModel.getRepoInfo(
+                          context, index, _scrollController);
                       return repo == null
                           ? null
                           : RepositoryCard(
                               index: index,
-                              name: repo.name,
+                              name: '$index:${repo.name}',
                               onPressed: (BuildContext context, int index) {
                                 // カードがタップされたら、DetailPage で詳細を表示する。
                                 DetailPageRoute(index: index).go(context);

--- a/lib/presentation/results_page/page_widget/results_page_widget.dart
+++ b/lib/presentation/results_page/page_widget/results_page_widget.dart
@@ -68,12 +68,15 @@ class ResultsPage extends HookConsumerWidget {
                   delegate: SliverChildBuilderDelegate(
                     (BuildContext context, int index) {
                       final RepoModel? repo = viewModel.getRepoInfo(
-                          context, index, _scrollController,);
+                        context,
+                        index,
+                        _scrollController,
+                      );
                       return repo == null
                           ? null
                           : RepositoryCard(
                               index: index,
-                              name: '$index:${repo.name}',
+                              name: repo.name,
                               onPressed: (BuildContext context, int index) {
                                 // カードがタップされたら、DetailPage で詳細を表示する。
                                 DetailPageRoute(index: index).go(context);

--- a/lib/presentation/results_page/page_widget/results_page_widget.dart
+++ b/lib/presentation/results_page/page_widget/results_page_widget.dart
@@ -68,7 +68,7 @@ class ResultsPage extends HookConsumerWidget {
                   delegate: SliverChildBuilderDelegate(
                     (BuildContext context, int index) {
                       final RepoModel? repo = viewModel.getRepoInfo(
-                          context, index, _scrollController);
+                          context, index, _scrollController,);
                       return repo == null
                           ? null
                           : RepositoryCard(

--- a/lib/presentation/results_page/view_model/results_page_view_model.dart
+++ b/lib/presentation/results_page/view_model/results_page_view_model.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 // ignore: depend_on_referenced_packages
 import 'package:async/async.dart';
@@ -33,16 +34,49 @@ class ResultsPageViewModel extends _$ResultsPageViewModel {
   /// 検索完了フラグ
   bool get isComplete => state.condition == Condition.complete;
 
+  /// Android スクロール位置補正用（アイテム高）
+  double _itemHeight = 0;
+
+  /// Android スクロール位置補正用（スクロール位置）
+  double _maxOffset = 0;
+
   /// index 番号指定のリポジトリ情報を取得する。
-  RepoModel? getRepoInfo(BuildContext context, int index) {
+  RepoModel? getRepoInfo(
+    BuildContext context,
+    int index,
+    ScrollController scrollController,
+  ) {
     final ({RepoModel? repo, int left}) res =
         searchRepoService.getRepoInfo(index);
+
+    final double maxScroll =
+        res.repo != null && scrollController.position.hasContentDimensions
+            ? scrollController.position.maxScrollExtent
+            : 0;
+
+    final double offset =
+        res.repo != null && scrollController.position.hasPixels
+            ? scrollController.position.pixels
+            : 0;
+
+    _maxOffset = offset == 0 ? _maxOffset : offset;
+    _itemHeight = offset == 0 ? (_maxOffset / index - 1) : (_maxOffset / index);
+
     // データ未取得でかつ、取得可能であれば次ページデータを取得する。
     if (res.repo == null && res.left > 0) {
       // 次ページの検索を実行
       Future<void>.delayed(const Duration(milliseconds: 500), () {
-        // ignore: discarded_futures
-        cacheStrategy.fetch(() => searchNext(context));
+        unawaited(
+          cacheStrategy.fetch(
+            () async {
+              await searchNext(context);
+              if (Platform.isAndroid) {
+                // Android は、データロード後にスクロール位置をロストするため補正を入れる
+                scrollController.jumpTo(_maxOffset + _itemHeight * 5);
+              }
+            },
+          ),
+        );
       });
     }
     return res.repo;

--- a/lib/presentation/results_page/view_model/results_page_view_model.dart
+++ b/lib/presentation/results_page/view_model/results_page_view_model.dart
@@ -49,11 +49,6 @@ class ResultsPageViewModel extends _$ResultsPageViewModel {
     final ({RepoModel? repo, int left}) res =
         searchRepoService.getRepoInfo(index);
 
-    final double maxScroll =
-        res.repo != null && scrollController.position.hasContentDimensions
-            ? scrollController.position.maxScrollExtent
-            : 0;
-
     final double offset =
         res.repo != null && scrollController.position.hasPixels
             ? scrollController.position.pixels

--- a/lib/use_case/service/search_repo_info_service.dart
+++ b/lib/use_case/service/search_repo_info_service.dart
@@ -22,7 +22,7 @@ class SearchRepoService {
   ///
   /// 返却値
   /// - repo: リポジトリ情報（検索エラーや有効な index でない場合は nullが返る）
-  /// - left: 未取得件数 （検索エラーや有効な index でない場合は 0以下が返る）
+  /// - left: 未取得件数 （検索エラーや有効な index でない場合は 0が返る）
   ({int left, RepoModel? repo}) getRepoInfo(int index) {
     if (_searchInfo == null) {
       return (repo: null, left: 0);
@@ -31,13 +31,14 @@ class SearchRepoService {
     final SearchInfo info = _searchInfo!;
     final int loaded = info.repositories.length;
     final int left = info.totalCount - loaded;
+
     if (index < loaded) {
       return (repo: info.repositories[index], left: left);
     }
     if (index < info.totalCount) {
       return (repo: null, left: left);
     }
-    return (repo: null, left: info.totalCount - index);
+    return (repo: null, left: 0);
   }
 
   /// クエリで検索を開始する。

--- a/test/use_case_service/use_case_service_search_repository_widget_test.dart
+++ b/test/use_case_service/use_case_service_search_repository_widget_test.dart
@@ -98,8 +98,10 @@ void main() {
     // 検索一覧の ChatApp リポジトリ名の情報詳細を取得する（ChatAppは、7番目で index は6）
     final ({int left, RepoModel? repo}) res = useCaseService.getRepoInfo(6);
     expect(res.repo!.name, 'ChatApp'); //リポジトリ名
-    expect(res.repo!.ownerAvatarUrl,
-        'https://avatars.githubusercontent.com/u/112800723?v=4',); //オーナーアイコン URL
+    expect(
+      res.repo!.ownerAvatarUrl,
+      'https://avatars.githubusercontent.com/u/112800723?v=4',
+    ); //オーナーアイコン URL
     // 【参考】同一シチュエーションでの Detail Page 画面表示については、
     // Results Page の検索一覧の7番目(index 6)をタップしたときのスナップショットを参照
     // test/use_case_service/search_result_index_6_chatApp_detail_page.png
@@ -140,7 +142,8 @@ void main() {
     // 無限スクロールが発生したとして、次ページ検査検索を実行させる。
     // 検索結果一覧画面 Results Page の context 取得
     final BuildContext context = tester.element(
-        find.byWidgetPredicate((Widget widget) => widget is ResultsPage),);
+      find.byWidgetPredicate((Widget widget) => widget is ResultsPage),
+    );
     final SearchInfo? secondState =
         await useCaseService.addNextRepositories(context: context);
 

--- a/test/use_case_service/use_case_service_test_mocks.dart
+++ b/test/use_case_service/use_case_service_test_mocks.dart
@@ -8,6 +8,7 @@ import 'package:search_repositories_on_github/use_case/service/search_repo_info_
 
 class MockRestApiService extends RestApiService {
   MockRestApiService(this.page1, this.page2, this.page3);
+
   final String page1;
   final String page2;
   final String page3;


### PR DESCRIPTION
# プルリクエスト説明
## 目的
無限スクロールによる追加検索結果の一覧表示について、
Android Platform では、追加検索後にスクロール位置をロストする現象を確認した。

このプラットフォーム不具合により、無限スクロールでの追加検索後に、
スクロール位置をロストするため手動で下スクロール操作が必要になっていた。

- Next Search のため無限スクロールを戻す操作が必要なことがある。
  #72

この現象は、iOS では発生しないため Android プラットフォームの問題として、
スクロールコントローラーで追加検索前のスクロール位置を保持しておき、
検索終了後にスクロール位置を補正する対応を行った。


## 対応 ISSUE
Close #72


## 対応内容
ResultsPage （検索結果一覧画面）に、ScrollController を追加し、
無限スクロールでの Next Search 発生時にスクロール位置を保管し、
つい以下検索終了後にスクロール位置を補正するようにした。

なお iOS では、この対応は必要ない。


## 妥協点
スクロール位置を取得は、ScrollController の position.maxScrollExtent で取得できるが、
素早くスクロールするなどにより、キー入力を貯めるとスクロール位置が特定できなくなる。
このため補正されるスクロール位置は近似値を使用したので、素早いスクロールでは位置ズレが発生する。


## テスト
- Android 端末でも無限スクロールによる Next Search 検索後に、
  スクロールの張り付きがなくなっています。

![追加検索による無限スクロール張り付きを修正](https://github.com/user-attachments/assets/e5f28e86-f28c-4a9c-88d2-3535599b7e8a)


