### PR TITLE
ユーザがエラーダイアログを確認するまで処理を待機するよう改訂

### DIFF
--- a/lib/presentation/results_page/view_model/results_page_view_model.dart
+++ b/lib/presentation/results_page/view_model/results_page_view_model.dart
@@ -10,6 +10,7 @@ import 'package:search_repositories_on_github/use_case/publications.dart';
 
 import '../../../domain/publications.dart';
 import '../../shared_state_on_pages/state/search_condition_state.dart';
+import '../../ui_components/error_dialog.dart';
 
 part 'results_page_view_model.g.dart';
 
@@ -33,6 +34,9 @@ class ResultsPageViewModel extends _$ResultsPageViewModel {
 
   /// 検索完了フラグ
   bool get isComplete => state.condition == Condition.complete;
+
+  /// 検索エラーフラグ
+  bool get hasError => isError;
 
   /// Android スクロール位置補正用（アイテム高）
   double _itemHeight = 0;
@@ -69,6 +73,23 @@ class ResultsPageViewModel extends _$ResultsPageViewModel {
                 // Android は、データロード後にスクロール位置をロストするため補正を入れる
                 scrollController.jumpTo(_maxOffset + _itemHeight * 5);
               }
+
+              if (isError) {
+                // 検索キューをフラッシュする。
+                cacheStrategy.invalidate();
+                debugLog('getRepoInfo  error occur.');
+
+                // ユーザへのエラー確認チェック要請
+                Future<void>.delayed(const Duration(milliseconds: 500), () {
+                  unawaited(
+                    cacheStrategy.fetch(
+                      () async {
+                        await errorConfirmed(context);
+                      },
+                    ),
+                  );
+                });
+              }
             },
           ),
         );
@@ -95,6 +116,24 @@ class ResultsPageViewModel extends _$ResultsPageViewModel {
       // 検索コンディションをエラーに更新
       state = state.copyWith(condition: Condition.error);
       debugLog('searchNext  error\n');
+    }
+  }
+
+  Future<void> errorConfirmed(BuildContext context) async {
+    debugLog('errorConfirmed - condition=${state.condition.name}');
+
+    if (hasError) {
+      final ErrorInfo errorInfo = searchRepoService.errorInfo!;
+      final PresentationErrorDialog errorDialog = PresentationErrorDialog();
+      await errorDialog.showErrorAlertDialog(
+        context: context,
+        title: errorInfo.title,
+        message: errorInfo.message,
+      );
+
+      // ユーザがエラーを確認したので検索コンディションを更新する。
+      state = state.copyWith(condition: Condition.before);
+      debugLog('errorConfirmed  before\n');
     }
   }
 }

--- a/lib/presentation/results_page/view_model/results_page_view_model.dart
+++ b/lib/presentation/results_page/view_model/results_page_view_model.dart
@@ -38,9 +38,6 @@ class ResultsPageViewModel extends _$ResultsPageViewModel {
   /// 検索エラーフラグ
   bool get hasError => isError;
 
-  /// Android スクロール位置補正用（アイテム高）
-  double _itemHeight = 0;
-
   /// Android スクロール位置補正用（スクロール位置）
   double _maxOffset = 0;
 
@@ -59,7 +56,6 @@ class ResultsPageViewModel extends _$ResultsPageViewModel {
             : 0;
 
     _maxOffset = offset == 0 ? _maxOffset : offset;
-    _itemHeight = offset == 0 ? (_maxOffset / index - 1) : (_maxOffset / index);
 
     // データ未取得でかつ、取得可能であれば次ページデータを取得する。
     if (res.repo == null && res.left > 0) {
@@ -71,7 +67,9 @@ class ResultsPageViewModel extends _$ResultsPageViewModel {
               await searchNext(context);
               if (Platform.isAndroid) {
                 // Android は、データロード後にスクロール位置をロストするため補正を入れる
-                scrollController.jumpTo(_maxOffset + _itemHeight * 5);
+                scrollController.jumpTo(
+                  _maxOffset + ((_maxOffset / (index - 5 * 2)) * 5),
+                );
               }
 
               if (isError) {
@@ -84,6 +82,12 @@ class ResultsPageViewModel extends _$ResultsPageViewModel {
                   unawaited(
                     cacheStrategy.fetch(
                       () async {
+                        if (Platform.isAndroid) {
+                          // Android は、スクロール位置をロストしているため補正を入れる
+                          scrollController.jumpTo(
+                            _maxOffset - ((_maxOffset / (index - 5 * 2)) * 2),
+                          );
+                        }
                         await errorConfirmed(context);
                       },
                     ),

--- a/lib/presentation/results_page/view_model/results_page_view_model.g.dart
+++ b/lib/presentation/results_page/view_model/results_page_view_model.g.dart
@@ -7,7 +7,7 @@ part of 'results_page_view_model.dart';
 // **************************************************************************
 
 String _$resultsPageViewModelHash() =>
-    r'9d9fe357e76df4fb1a1e8a67997c5ea346d837bd';
+    r'd05fc2e298e7f448b006e454e2820db746c5ed2d';
 
 /// （riverpod での notifier） ResultsPage ViewModel
 ///

--- a/lib/presentation/search_page/view_model/search_page_view_model.g.dart
+++ b/lib/presentation/search_page/view_model/search_page_view_model.g.dart
@@ -7,7 +7,7 @@ part of 'search_page_view_model.dart';
 // **************************************************************************
 
 String _$searchPageViewModelHash() =>
-    r'480a8b64e23c0c04cb987016e31abe2d9e57c00d';
+    r'c2a3e9f2d2c782c1e62948ce5a88e0ba65204321';
 
 /// （riverpod での notifier） SearchPage ViewModel
 ///

--- a/lib/presentation/ui_components/error_dialog.dart
+++ b/lib/presentation/ui_components/error_dialog.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+/// プレゼンテーションのエラーダイアログ表示
+class PresentationErrorDialog {
+  Future<void> showErrorAlertDialog({
+    required BuildContext context,
+    required String title,
+    required String message,
+  }) async {
+    if (context.mounted) {
+      await showDialog<void>(
+        context: context,
+        useRootNavigator: true,
+        barrierDismissible: false,
+        builder: (BuildContext context) {
+          // バックボタンでのダイアログ表示クローズを抑止します。
+          return PopScope(
+            canPop: false,
+            child: AlertDialog(
+              title: Text(title),
+              content: SingleChildScrollView(
+                child: Text(message),
+              ),
+              actions: <Widget>[
+                TextButton(
+                  onPressed: () {
+                    Navigator.pop(context);
+                  },
+                  child: const Text('OK'),
+                ),
+              ],
+            ),
+          );
+        },
+      );
+    }
+  }
+}

--- a/lib/use_case/error/use_case_error_dialog.dart
+++ b/lib/use_case/error/use_case_error_dialog.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 /// ユースケースレベルのエラーダイアログ表示サービス
-class UseCaseErrorHDialog {
+class UseCaseErrorDialog {
   Future<void> showErrorAlertDialog({
     required BuildContext context,
     required String title,

--- a/lib/use_case/service/search_repo_info_service.dart
+++ b/lib/use_case/service/search_repo_info_service.dart
@@ -11,12 +11,17 @@ import '../error/use_case_error_dialog.dart';
 class SearchRepoService {
   SearchRepoService(this._repository);
   final SearchedRepoRepository _repository;
-  final UseCaseErrorHDialog _errorDialog = UseCaseErrorHDialog();
+  final UseCaseErrorDialog _errorDialog = UseCaseErrorDialog();
 
   SearchInfo? _searchInfo;
 
   /// ユースケースレベルの検索情報
   SearchInfo? get searchInfo => _searchInfo;
+
+  ErrorInfo? _errorInfo;
+
+  /// ユースケースレベルのエラー情報
+  ErrorInfo? get errorInfo => _errorInfo;
 
   /// index 番号で示されたリポジトリ情報を取得します。
   ///
@@ -186,4 +191,18 @@ class SearchInfo {
 
   /// 取得済みの検索リポジトリのリスト（可変）
   final List<RepoModel> repositories;
+}
+
+/// ユースケースレベルのエラー情報モデル
+class ErrorInfo {
+  ErrorInfo({
+    required this.title,
+    required this.message,
+  });
+
+  /// エラータイトル
+  final String title;
+
+  /// エラーメッセージ
+  final String message;
 }

--- a/lib/use_case/service/search_repo_info_service.dart
+++ b/lib/use_case/service/search_repo_info_service.dart
@@ -145,6 +145,7 @@ class SearchRepoService {
       );
 
       if (context.mounted) {
+        final String title = l10n(context).errorDialogTitle;
         final String message = switch (exp.type) {
           DomainExceptionType.emptyQuery =>
             l10n(context).errorMessageEmptyQuery,
@@ -158,11 +159,7 @@ class SearchRepoService {
             l10n(context).errorMessageUnknownException,
           _ => l10n(context).errorMessageApiProblem,
         };
-        await _errorDialog.showErrorAlertDialog(
-          context: context,
-          title: l10n(context).errorDialogTitle,
-          message: message,
-        );
+        _errorInfo = ErrorInfo(title: title, message: message);
       }
     }
     return null;


### PR DESCRIPTION
# プルリクエスト説明
## 目的
Next Search 条件下で、検索レート超過エラーが繰り返し表示されないように、
ユーザがエラーダイアログを確認するまで処理を待機するように修正しました。


## 対応 ISSUE
Close #75


## 対応内容
エラー状況下では、ユーザによるエラー確認が行われるまで、
SearchService 処理を待機させるようにしました。

-  UseCase 層の SearchService でエラー情報を作り、  
  ユーザにエラー確認を要請するため、プレゼン層用のエラーダイアログを追加

- ドメイン知識が漏れないようにするため、  
  プレゼン層には、国際化したエラー文言のみ提供させています。  
  - プレゼン層は、エラーがあったことのみ通知し、
    ドメイン知識を前提とするエラー内容には触れさせていません。

## 妥協点
Android プラットフォーム固有問題のスクロール位置補正は、  
iOS と異なり状況によりスクロール位置が変化するため近似値です。  


## テスト
- エラーダイアログが閉じるまで、Next Search を待機させ、  
  検索レート超過エラーダイアログの繰り返し表示を抑止しています。
  - スクロール位置の補正をわかりやすくするため、リポジトリ名に仕様にない index 番号を付与しています。

![検索レート超過エラーの表示確認待機を追加](https://github.com/user-attachments/assets/b187583a-ef4b-4141-8819-507a98268e6f)
