### PR TITLE
UseCase SearchService でのエラー情報の提供を Next Search エラー時に限定させます。

### DIFF
--- a/lib/use_case/service/search_repo_info_service.dart
+++ b/lib/use_case/service/search_repo_info_service.dart
@@ -29,6 +29,9 @@ class SearchRepoService {
   /// - repo: リポジトリ情報（検索エラーや有効な index でない場合は nullが返る）
   /// - left: 未取得件数 （検索エラーや有効な index でない場合は 0が返る）
   ({int left, RepoModel? repo}) getRepoInfo(int index) {
+    // エラー情報をクリア
+    _errorInfo = null;
+
     if (_searchInfo == null) {
       return (repo: null, left: 0);
     }
@@ -59,6 +62,9 @@ class SearchRepoService {
   }) async {
     // 検索情報を初期化
     _searchInfo = null;
+
+    // エラー情報をクリア
+    _errorInfo = null;
 
     final List<QueryItem> items = <QueryItem>[];
     _addQueryItem(items, InFilter.readme, readme);
@@ -122,6 +128,9 @@ class SearchRepoService {
   Future<SearchInfo?> addNextRepositories({
     required BuildContext context,
   }) async {
+    // エラー情報をクリア
+    _errorInfo = null;
+
     // 次ページ検索条件チェック
     if (searchInfo == null ||
         searchInfo!.totalCount == searchInfo!.repositories.length) {
@@ -159,6 +168,7 @@ class SearchRepoService {
             l10n(context).errorMessageUnknownException,
           _ => l10n(context).errorMessageApiProblem,
         };
+        // エラー情報を設定（ドメイン知識が漏出しないようメッセージのみ提供）
         _errorInfo = ErrorInfo(title: title, message: message);
       }
     }


### PR DESCRIPTION
# プルリクエスト説明
## 目的
UseCase レイヤの設計指針として、
ドメインからのデータやロジックをプレゼン層に漏出させない責務を持つと定義しているので、
エラー情報もドメイン知識の片鱗であるため、提供機会を限定し不必要な提供を抑止します。

## 対応 ISSUE
Close #78

## 対応内容
エラー情報の提供は、ユーザによるエラー確認操作を求める
UseCase SearchService の addNextRepositories に限定させています。
