### PR TITLE
実態調査から獲得したドメイン知識をクエリパラメータのバリデーションに反映。

### DIFF
--- a/lib/application/l10n/gen/app_localizations.dart
+++ b/lib/application/l10n/gen/app_localizations.dart
@@ -143,7 +143,7 @@ abstract class AppLocalizations {
   /// No description provided for @errorMessageTooLongQuery.
   ///
   /// In ja, this message translates to:
-  /// **'検索クエリは、256文字までです。'**
+  /// **'検索条件が長すぎます、合計で256文字未満にしてください。'**
   String get errorMessageTooLongQuery;
 
   /// No description provided for @errorMessageDioException.

--- a/lib/application/l10n/gen/app_localizations_en.dart
+++ b/lib/application/l10n/gen/app_localizations_en.dart
@@ -31,7 +31,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get errorMessageTooLongQuery =>
-      'Search queries cannot exceed 256 characters.';
+      'Search parameters are too long, please limit them to less than 256 characters total.';
 
   @override
   String get errorMessageDioException =>

--- a/lib/application/l10n/gen/app_localizations_ja.dart
+++ b/lib/application/l10n/gen/app_localizations_ja.dart
@@ -30,7 +30,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get errorMessageEmptyQuery => '検索クエリがありません。';
 
   @override
-  String get errorMessageTooLongQuery => '検索クエリは、256文字までです。';
+  String get errorMessageTooLongQuery => '検索条件が長すぎます、合計で256文字未満にしてください。';
 
   @override
   String get errorMessageDioException => 'ネットワーク通信に問題がでました。';

--- a/lib/application/l10n/resource/app_en.arb
+++ b/lib/application/l10n/resource/app_en.arb
@@ -8,7 +8,7 @@
   "errorButtonCancel": "Cancel",
 
   "errorMessageEmptyQuery": "There is no search query.",
-  "errorMessageTooLongQuery": "Search queries cannot exceed 256 characters.",
+  "errorMessageTooLongQuery": "Search parameters are too long, please limit them to less than 256 characters total.",
   "errorMessageDioException": "A network communication problem occurred.",
   "errorMessageOverRateLimits": "You have exceeded search rate limit.\nPlease refrain from using for a while.",
   "errorMessageUnknownException": "An unexpected problem occurred.",

--- a/lib/application/l10n/resource/app_ja.arb
+++ b/lib/application/l10n/resource/app_ja.arb
@@ -11,7 +11,7 @@
   "errorButtonCancel": "Cancel",
 
   "errorMessageEmptyQuery": "検索クエリがありません。",
-  "errorMessageTooLongQuery": "検索クエリは、256文字までです。",
+  "errorMessageTooLongQuery": "検索条件が長すぎます、合計で256文字未満にしてください。",
   "errorMessageDioException": "ネットワーク通信に問題がでました。",
   "errorMessageOverRateLimits": "検索レート制限を越えました、しばらく利用を控えてください。",
   "errorMessageUnknownException": "想定外の問題が発生しました。",

--- a/lib/domain/models/search_filers.dart
+++ b/lib/domain/models/search_filers.dart
@@ -3,6 +3,14 @@ class Query {
   Query(this.params);
   final List<QueryItem> params;
 
+  String toParamStr() {
+    final StringBuffer sb = StringBuffer();
+    for (final QueryItem item in params) {
+      sb.write(item.paramStr);
+    }
+    return sb.toString();
+  }
+
   String toQueryStr() {
     final StringBuffer sb = StringBuffer();
     for (final QueryItem item in params) {

--- a/lib/domain/models/search_filers.dart
+++ b/lib/domain/models/search_filers.dart
@@ -9,7 +9,7 @@ class Query {
       if (sb.isNotEmpty) {
         sb.write(' ');
       }
-      sb.write(item.label);
+      sb.write(item.queryStr);
     }
     return sb.toString();
   }
@@ -17,8 +17,9 @@ class Query {
 
 /// Queryアイテムを表すバリュークラス
 class QueryItem {
-  QueryItem(this.label);
-  final String label;
+  QueryItem(this.paramStr, this.queryStr);
+  final String paramStr;
+  final String queryStr;
 }
 
 /// （検索条件フィルタ）キーワードが条件に含まれているリポジトリで絞り込みます。
@@ -35,16 +36,17 @@ enum InFilter {
   /// in:readme キーワードがREADME ファイル内に含まれている。
   readme('in:readme');
 
-  const InFilter(this.searchType);
+  const InFilter(this.qualifier);
 
-  final String searchType;
+  final String qualifier;
 
   QueryItem toQueryItem(String keyword) {
-    return QueryItem('"$keyword" $searchType');
+    final String param = keyword.replaceAll('"', ' ');
+    return QueryItem(param, '"$param" $qualifier');
   }
 }
 
-//FIXME ロジック考慮中
+//FIXME ロジック考慮中 (全パターン網羅不全のため保留)
 /// （検索条件フィルタ）条件が範囲内のリポジトリで絞り込みます。
 enum RangeFilter {
   size('size'),
@@ -53,18 +55,25 @@ enum RangeFilter {
   stars('start'),
   topics('topics');
 
-  const RangeFilter(this.label);
-  final String label;
-  QueryItem toQueryItem({required Range range, required int value}) =>
-      QueryItem('$label:"$name"');
+  const RangeFilter(this.qualifier);
+  final String qualifier;
+  QueryItem toQueryItem({required Range range, required int value}) {
+    final String param = value.toString();
+    return QueryItem(param, '$qualifier:${range.operator}$param');
+  }
 }
 
-//FIXME ロジック考慮中
+//FIXME ロジック考慮中 (全パターン網羅不全のため保留)
 enum Range {
-  equals(),
-  large,
-  small,
-  range;
+  // range(':%..%'),
+  equals(''),
+  large('>'),
+  small('<'),
+  graterEquals('>='),
+  smallerEquals('<=');
+
+  const Range(this.operator);
+  final String operator;
 }
 
 /// （検索条件フィルタ）キーワードが条件に含まれているリポジトリで絞り込みます。
@@ -75,9 +84,12 @@ enum SingleMachFilter {
   /// キーワードが組織名に含まれている。
   org('org');
 
-  const SingleMachFilter(this.label);
-  final String label;
-  QueryItem toQueryItem({required String name}) => QueryItem('$label:"$name"');
+  const SingleMachFilter(this.qualifier);
+  final String qualifier;
+  QueryItem toQueryItem({required String name}) {
+    final String param = name.replaceAll('"', ' ');
+    return QueryItem(param, '$qualifier:"$param"');
+  }
 }
 
 /// （検索条件フィルタ）キーワードが条件に含まれているリポジトリで絞り込みます。
@@ -85,10 +97,13 @@ enum DoubleMachFilter {
   /// オーナー名やリポジトリ名で絞り込みます。
   repo('repo');
 
-  const DoubleMachFilter(this.label);
-  final String label;
-  QueryItem toQueryItem({required String userName, required String repoName}) =>
-      QueryItem('$label:"$userName"/"$repoName"');
+  const DoubleMachFilter(this.qualifier);
+  final String qualifier;
+  QueryItem toQueryItem({required String userName, required String repoName}) {
+    final String param1 = userName.replaceAll('"', ' ');
+    final String param2 = repoName.replaceAll('"', ' ');
+    return QueryItem('$param1 $param2', '$qualifier:"$param1"/"$param2"');
+  }
 }
 
 /// （検索条件フィルタ）条件を満たすリポジトリで絞り込みます。
@@ -102,9 +117,11 @@ enum BoolFilter {
   /// リポジトリがアーカイブされているか否かで絞込みます。
   archived('archived');
 
-  const BoolFilter(this.label);
-  final String label;
-  QueryItem toQueryItem({required bool flag}) => QueryItem('$label:$flag');
+  const BoolFilter(this.qualifier);
+  final String qualifier;
+  QueryItem toQueryItem({required bool flag}) {
+    return QueryItem('$flag', '$qualifier:$flag');
+  }
 }
 
 /// （検索条件フィルタ）条件を満たすリポジトリで絞り込みます。
@@ -115,7 +132,7 @@ enum SingleFilter {
   /// リポジトリに Founding ファイルがあるか否かで絞り込みます。
   fundingFile('has:funding-file');
 
-  const SingleFilter(this.label);
-  final String label;
-  QueryItem toQueryItem() => QueryItem(label);
+  const SingleFilter(this.qualifier);
+  final String qualifier;
+  QueryItem toQueryItem() => QueryItem('', qualifier);
 }


### PR DESCRIPTION
# プルリクエスト説明
## 目的
バリデーションを適用するためには、GitHub search repository API ドメイン知識が必要です。
一般的にクエリパラメータは、URI エンコーディングされ 8000 オクテットを扱えるとされています。

GitHub search repository API サービスでは、256文字を越えないように要請されていますが①、
URI エンコードやエスケープ対象および、マルチバイト文字や Ascii 文字との扱い違いなど、
API サービス側運用都合詳細は不明であるため、制限実態の調査を行いました。

獲得したドメイン知識を QueryParameter モデルおよびバリデーションチェック・ロジックに反映しました。

- ① ISSUE #85 参照


## 対応 ISSUE
Close #85


## 対応内容
### 調査結果
- クエリパラメータの `in:readme` など quarifier 部は最大長制限に含めない。  
  ドキュメントより、クエリパラメータの quarifier 部は最大長制限に含めないとあります。
  - [Limitations on query length](https://docs.github.com/en/rest/search/search?apiVersion=2022-11-28#limitations-on-query-length)  
    クエリの長​​さの制限  
    以下の検索クエリは、"Validation failed" というエラー メッセージを返します。
    ・256 文字を超えるもの (演算子や qualifiers ⇒ in:readme などは含みません)
    ・AND、OR、NOT または演算子が5つ以上あるもの。

- マルチバイト文字も１文字として換算していた。
  クエリパラメータが、マルチバイト文字であっても、
  URI クエリパラメータ・エスケープ対象文字でも、1文字として換算していた。
  また最大長は、256文字よりも小さい 245文字で扱う必要があった。

- 獲得したドメイン知識をクエリパラーメタのバリデーション機能を担う QueryItem モデルや Query に反映しました。


### 調査結果ログ
- Ascii 文字 256文字未満だが、250文字だと 422 エラーとなった。
```
flutter: searchRepositories -
flutter:  - paramString[253]=0123456789@ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz 0123456789@ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz 0123456789@ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz 0123456789@ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrst
flutter:  - paramUriEncode[269]=0123456789%40ABCDEFGHIJKLMNOPQRSTUVWXYZ%2Fabcdefghijklmnopqrstuvwxyz+0123456789%40ABCDEFGHIJKLMNOPQRSTUVWXYZ%2Fabcdefghijklmnopqrstuvwxyz+0123456789%40ABCDEFGHIJKLMNOPQRSTUVWXYZ%2Fabcdefghijklmnopqrstuvwxyz+0123456789%40ABCDEFGHIJKLMNOPQRSTUVWXYZ%2Fabcdefghijklmnopqrst
flutter:  - queryString[304]="0123456789@ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz" in:readme "0123456789@ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz" in:description "0123456789@ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz" in:name "0123456789@ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrst" in:topics
flutter:  - queryUriEncode[344]=%220123456789%40ABCDEFGHIJKLMNOPQRSTUVWXYZ%2Fabcdefghijklmnopqrstuvwxyz%22+in%3Areadme+%220123456789%40ABCDEFGHIJKLMNOPQRSTUVWXYZ%2Fabcdefghijklmnopqrstuvwxyz%22+in%3Adescription+%220123456789%40ABCDEFGHIJKLMNOPQRSTUVWXYZ%2Fabcdefghijklmnopqrstuvwxyz%22+in%3Aname+%220123456789%40ABCDEFGHIJKLMNOPQRSTUVWXYZ%2Fabcdefghijklmnopqrst%22+in%3Atopics
flutter:
flutter: [GET] request - data={q: "0123456789@ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz" in:readme "0123456789@ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz" in:description "0123456789@ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz" in:name "0123456789@ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrst" in:topics, sort: updated, order: desc, per_page: 20, page: 1}
flutter:
flutter:
flutter: [GET] exception {
flutter:     requestOptions.path: https://api.github.com/search/repositories
flutter:     requestOptions.data:
flutter:     message: This exception was thrown because the response has a status code of 422 and RequestOptions.validateStatus was configured to throw for this status code.
flutter: The status code of 422 has the following meaning: "Client error - the request contains bad syntax or cannot be fulfilled"
flutter: Read more about status codes at https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
flutter: In order to resolve this exception you typically have either to verify and fix your request code or you have to fix the server code.
flutter:
flutter:     response.statusCode: 422
flutter:     response.data: {message: Validation Failed, errors: [{message: The search is longer than 256 characters., resource: Search, field: q, code: invalid}], documentation_url: https://docs.github.com/v3/search/, status: 422}
```

- Ascii 文字 245 に制限すれば、レスポンスが取得できた。
```
flutter: searchRepositories -
flutter:  - paramString[248]=0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzZZ 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzZZ 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzZZ 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopq
flutter:  - paramUriEncode[248]=0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzZZ+0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzZZ+0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzZZ+0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopq
flutter:  - queryString[299]="0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzZZ" in:readme "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzZZ" in:description "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzZZ" in:name "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopq" in:topics
flutter:  - queryUriEncode[323]=%220123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzZZ%22+in%3Areadme+%220123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzZZ%22+in%3Adescription+%220123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzZZ%22+in%3Aname+%220123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopq%22+in%3Atopics
flutter:
flutter: [GET] request - data={q: "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzZZ" in:readme "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzZZ" in:description "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzZZ" in:name "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopq" in:topics, sort: updated, order: desc, per_page: 20, page: 1}
flutter:
flutter:
flutter: [GET] response {
flutter:     request.uri: https://api.github.com/search/repositories?q=%220123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzZZ%22+in%3Areadme+%220123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzZZ%22+in%3Adescription+%220123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzZZ%22+in%3Aname+%220123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopq%22+in%3Atopics&sort=updated&order=desc&per_page=20&page=1
flutter:     response.statusCode: 200
flutter:     response.data: {total_count: 0, incomplete_results: false, items: []}
flutter:     response.headers: - omission -
flutter: }
flutter:
flutter: SearchRepoInfoModel - total count=0, items=0, query="0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzZZ" in:readme "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzZZ" in:description "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzZZ" in:name "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopq" in:topics, perPage=20, currentPage=1
flutter: searchRepoByInQuery totalCount=0, loadedCount=0
```


- マルチバイト文字や Ascii 文字を区別せず 246文字 では、422 エラーとなった。
```
flutter: searchRepositories - paramString[246]=012345あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもアイウエオカキクケコサシスセソタチツテトナニヌネノオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモ０１２３４５６７８９あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもアイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモ０１２３４５６７８９
flutter:
flutter: [GET] request - data={q: "012345" in:readme "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもアイウエオカキクケコサシスセソタチツテトナニヌネなにぬねのはひふへほまみむめもアイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモ０１２３４５６７８９" in:name "あいうえおかきくけこさしすせそたちつてとなdated, order: desc, per_page: 20, page: 1}
flutter:
flutter:
flutter: [GET] exception {
flutter:     requestOptions.path: https://api.github.com/search/repositories
flutter:     requestOptions.data:
flutter:     message: This exception was thrown because the response has a status code of 422 and RequestOptions.validateStatus was configured to throw for this status code.
flutter: The status code of 422 has the following meaning: "Client error - the request contains bad syntax or cannot be fulfilled"
flutter: Read more about status codes at https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
flutter: In order to resolve this exception you typically have either to verify and fix your request code or you have to fix the server code.
flutter:
flutter:     response.statusCode: 422
flutter:     response.data: {message: Validation Failed, errors: [{message: The search is longer than 256 characters., resource: Search, field: q, code: invalid}], documentation_url: https://docs.github.com/v3/search/, status: 422}
```


- マルチバイト文字やエスケープ文字を区別せず、245文字以内であれば 422 エラーにならなかった。
```
flutter: searchRepositories - paramString[245]=01234あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもアイウエオカキクケコサシスセソタチツテトナニヌネノカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモ０１２３４５６７８９あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもアイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモ０１２３４５６７８９
flutter:
flutter: [GET] request - data={q: "01234" in:readme "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもアイウエオカキクケコサシスセソタチツテトナニヌネノにぬねのはひふへほまみむめもアイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモ０１２３４５６７８９" in:name "あいうえおかきくけこさしすせそたちつてとなにated, order: desc, per_page: 20, page: 1}
flutter:
flutter:
flutter: [GET] response {
flutter:     request.uri: https://api.github.com/search/repositories?q=%2201234%22+in%3Areadme+%22%E3%81%82%E3%81%84%E3%81%86%E3%81%88%E3%81%8A%E3%81%8B%E3%81%8D%E3%81%8F%E3%81%91%E3%81%93%E3%81%95%E3%81%97%E3%81%99%E3%81%9B%E3%81%9D%E3%81%9F%E3%81%A1%E3%81%A4%E3%81%A6%E3%81%A8%E3%81%AA%E3%81%AB%E3%81%AC%E3%81%AD%E3%81%AE%E3%81%AF%E3%81%B2%E3%81%B5%E3%81%B8%E3%81%BB%E3%81%BE%E3%81%BF%E3%82%80%E3%82%81%E3%82%82%E3%82%A2%E3%82%A4%E3%82%A6%E3%82%A8%E3%82%AA%E3%82%AB%E3%82%AD%E3%82%AF%E3%82%B1%E3%82%B3%E3%82%B5%E3%82%B7%E3%82%B9%E3%82%BB%E3%82%BD%E3%82%BF%E3%83%81%E3%83%84%E3%83%86%E3%83%88%E3%83%8A%E3%83%8B%E3%83%8C%E3%83%8D%E3%83%8E%E3%83%8F%E3%83%92%E3%83%95%E3%83%98%E3%83%9B%E3%83%9E%E3%83%9F%E3%83%A0%E3%83%A1%E3%83%A2%EF%BC%90%EF%BC%91%EF%BC%92%EF%BC%93%EF%BC%94%EF%BC%95%EF%BC%96%EF%BC%97%EF%BC%98%EF%BC%99%22+in%3Adescription+%22%E3%81%82%E3%81%84%E3%81%86%E3%81%88%E3%81%8A%E3%81%8B%E3%81%8D%E3%81%8F%E3%81%91%E3%81%93%E3%81%95%E3%81%97%E3%81%99%E3%81%9B%E3%81%9D%E3%81%9F%E3%81%A1%E3%81%A4%E3%8<…>
flutter:     response.statusCode: 200
flutter:     response.data: {total_count: 0, incomplete_results: false, items: []}
flutter:     response.headers: - omission -
flutter: }
flutter:
flutter: SearchRepoInfoModel - total count=0, items=0, query="01234" in:readme "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもアイウエオカキクケコサtion "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもアイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモ０１２３４５６７８９" in:n５６７８９" in:topics, perPage=20, currentPage=1
```

- マルチバイト文字やエスケープ文字を区別せず、245文字以内であれば 422 エラーにならなかった。
  - 数字の代わりにエスケーピングされる @ を使っても最大文字数は変わらない。
```
flutter: searchRepositories - paramString[245]=@@@@@あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもアイウエオカキクケコサシスセソタチツテトナニヌネノカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモ０１２３４５６７８９あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもアイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモ０１２３４５６７８９
flutter:
flutter: [GET] request - data={q: "@@@@@" in:readme "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもアイウエオカキクケコサシスセソタチツテトナニヌネノにぬねのはひふへほまみむめもアイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモ０１２３４５６７８９" in:name "あいうえおかきくけこさしすせそたちつてとなにated, order: desc, per_page: 20, page: 1}
flutter:
flutter:
flutter: [GET] response {
flutter:     request.uri: https://api.github.com/search/repositories?q=%22%40%40%40%40%40%22+in%3Areadme+%22%E3%81%82%E3%81%84%E3%81%86%E3%81%88%E3%81%8A%E3%81%8B%E3%81%8D%E3%81%8F%E3%81%91%E3%81%93%E3%81%95%E3%81%97%E3%81%99%E3%81%9B%E3%81%9D%E3%81%9F%E3%81%A1%E3%81%A4%E3%81%A6%E3%81%A8%E3%81%AA%E3%81%AB%E3%81%AC%E3%81%AD%E3%81%AE%E3%81%AF%E3%81%B2%E3%81%B5%E3%81%B8%E3%81%BB%E3%81%BE%E3%81%BF%E3%82%80%E3%82%81%E3%82%82%E3%82%A2%E3%82%A4%E3%82%A6%E3%82%A8%E3%82%AA%E3%82%AB%E3%82%AD%E3%82%AF%E3%82%B1%E3%82%B3%E3%82%B5%E3%82%B7%E3%82%B9%E3%82%BB%E3%82%BD%E3%82%BF%E3%83%81%E3%83%84%E3%83%86%E3%83%88%E3%83%8A%E3%83%8B%E3%83%8C%E3%83%8D%E3%83%8E%E3%83%8F%E3%83%92%E3%83%95%E3%83%98%E3%83%9B%E3%83%9E%E3%83%9F%E3%83%A0%E3%83%A1%E3%83%A2%EF%BC%90%EF%BC%91%EF%BC%92%EF%BC%93%EF%BC%94%EF%BC%95%EF%BC%96%EF%BC%97%EF%BC%98%EF%BC%99%22+in%3Adescription+%22%E3%81%82%E3%81%84%E3%81%86%E3%81%88%E3%81%8A%E3%81%8B%E3%81%8D%E3%81%8F%E3%81%91%E3%81%93%E3%81%95%E3%81%97%E3%81%99%E3%81%9B%E3%81%9D%E3%81%9F%E3%81%A1%E3%<…>
flutter:     response.statusCode: 200
flutter:     response.data: {total_count: 0, incomplete_results: false, items: []}
flutter:     response.headers: - omission -
flutter: }
flutter:
flutter: SearchRepoInfoModel - total count=0, items=0, query="@@@@@" in:readme "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもアイウエオカキクケコサtion "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもアイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモ０１２３４５６７８９" in:n５６７８９" in:topics, perPage=20, currentPage=1
```


## 妥協点
実態を調査しましたが、何故最大長が 256文字でなかったのかの理由は解明していません。


## テスト
- クエリパラメータ最大長を超えると警告が表示され、
  最大長以内であれば、検索結果が返ります。
![クエリパラメータ最大長チェック](https://github.com/user-attachments/assets/ea21a4a5-7dde-4afc-8f5c-e7fe17183853)
