### PR TITLE
クエリパラメータ・バリデーションのリファクタリング

### DIFF
--- a/lib/domain/models/search_filers.dart
+++ b/lib/domain/models/search_filers.dart
@@ -6,7 +6,10 @@ class Query {
   String toParamStr() {
     final StringBuffer sb = StringBuffer();
     for (final QueryItem item in params) {
-      sb.write(item.paramStr);
+      if (sb.isNotEmpty) {
+        sb.write(' ');
+      }
+      sb.write('"${item.paramStr}"');
     }
     return sb.toString();
   }

--- a/lib/domain/repository/searched_repo_repository.dart
+++ b/lib/domain/repository/searched_repo_repository.dart
@@ -20,9 +20,7 @@ class SearchedRepoRepository {
   static const int parPage = 20;
 
   /// クエリパラメータ最大長
-  ///
-  /// _運用上の最大長は、調査の結果 256文字より小さかった。_
-  static const int maxQueryParameterSize = 245;
+  static const int maxQueryParameterSize = 256;
 
   /// リポジトリ検索開始
   ///


### PR DESCRIPTION
# プルリクエスト説明
## 目的
クエリパラメータ最大長についての 256文字からのズレの要因を特定し修正しました。


## 対応 ISSUE
Close #92


## 対応内容
クエリパラメータ出力のロジック toParamStr() での対応漏れを修正し、
クエリパラメータ最大長が 256文字 であることを確認し修正しました。

- Query.toParamStr() 対応漏れ
  - toParamStr: QueryItem 間のスペース出力漏れを修正
  - toParamStr: ダブルクォーテーション出力漏れを修正

_リファクタリングのため挙動の変更はありません。_


### 調査結果
- マルチバイト文字や Ascii 文字を区別せず 257 文字 では、422 エラーとなった。
```
I/flutter (19532): searchRepositories - paramString[257]="012345" "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもアイウエオカキクケコサシスセソタチツぬねのはひふへほまみむめもアイウエオカキクケコサシスセソタチツテトナニヌネノカキクケコサシスセソタチツテトナニヌネノ" "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもアイウエオカキクケコサシスセソタチツテトナニヌネノカキクケコサシスセソタチツテトナニヌネノ"
I/flutter (19532): [GET] request - data={q: "012345" in:readme "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもアイウエオカキクケコサシスセソタチツテさしすせそたちつてとなにぬねのはひふへほまみむめもアイウエオカキクケコサシスセソタチツテトナニヌネノカキクケコサシスセソタチツテトナニヌネノ" in:name "あいうえおかきくけこさ, sort: updated, order: desc, per_page: 20, page: 1}
I/flutter (19532): [GET] exception {
I/flutter (19532):     requestOptions.path: https://api.github.com/search/repositories
I/flutter (19532):     requestOptions.data: 
I/flutter (19532):     message: This exception was thrown because the response has a status code of 422 and RequestOptions.validateStatus was configured to throw for this status code.
I/flutter (19532): The status code of 422 has the following meaning: "Client error - the request contains bad syntax or cannot be fulfilled"
I/flutter (19532): Read more about status codes at https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
I/flutter (19532): In order to resolve this exception you typically have either to verify and fix your request code or you have to fix the server code.
I/flutter (19532):     response.statusCode: 422
I/flutter (19532):     response.data: {message: Validation Failed, errors: [{message: The search is longer than 256 characters., resource: Search, field: q, code: invalid}], documentation_url: https://docs.github.com/v3/search/, status: 422}
```

- マルチバイト文字やエスケープ文字を区別せず、256文字以内であれば 422 エラーにならなかった。
```
I/flutter (19532): searchRepositories - paramString[256]="01234" "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもアイウエオカキクケコサシスセソタチツねのはひふへほまみむめもアイウエオカキクケコサシスセソタチツテトナニヌネノカキクケコサシスセソタチツテトナニヌネノ" "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもアイウエオカキクケコサシスセソタチツテトナニヌネノカキクケコサシスセソタチツテトナニヌネノ"
I/flutter (19532): [GET] request - data={q: "01234" in:readme "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもアイウエオカキクケコサシスセソタチツテトしすせそたちつてとなにぬねのはひふへほまみむめもアイウエオカキクケコサシスセソタチツテトナニヌネノカキクケコサシスセソタチツテトナニヌネノ" in:name "あいうえおかきくけこさし sort: updated, order: desc, per_page: 20, page: 1}
I/flutter (19532): [GET] response {
I/flutter (19532):     request.uri: https://api.github.com/search/repositories?q=%2201234%22+in%3Areadme+%22%E3%81%82%E3%81%84%E3%81%86%E3%81%88%E3%81%8A%E3%81%8B%E3%81%8D%E3%81%8F%E3%81%91%E3%81%93%E3%81%95%E3%81%97%E3%81%99%E3%81%9B%E3%81%9D%E3%81%9F%E3%81%A1%E3%81%A4%E3%81%A6%E3%81%A8%E3%81%AA%E3%81%AB%E3%81%AC%E3%81%AD%E3%81%AE%E3%81%AF%E3%81%B2%E3%81%B5%E3%81%B8%E3%81%BB%E3%81%BE%E3%81%BF%E3%82%80%E3%82%81%E3%82%82%E3%82%A2%E3%82%A4%E3%82%A6%E3%82%A8%E3%82%AA%E3%82%AB%E3%82%AD%E3%82%AF%E3%82%B1%E3%82%B3%E3%82%B5%E3%82%B7%E3%82%B9%E3%82%BB%E3%82%BD%E3%82%BF%E3%83%81%E3%83%84%E3%83%86%E3%83%88%E3%83%8A%E3%83%8B%E3%83%8C%E3%83%8D%E3%83%8E%E3%82%AB%E3%82%AD%E3%82%AF%E3%82%B1%E3%82%B3%E3%82%B5%E3%82%B7%E3%82%B9%E3%82%BB%E3%82%BD%E3%82%BF%E3%83%81%E3%83%84%E3%83%86%E3%83%88%E3%83%8A%E3%83%8B%E3%83%8C%E3%83%8D%E3%83%8E%22+in%3Adescription+%22%E3%81%82%E3%81%84%E3%81%86%E3%81%88%E3%81%8A%E3%81%8B%E3%81%8D%E3%81%8F%E3%81%91%E3%81%93%E3%81%95%E3%81%97%E3%81%99%E3%81%9B%E3%81%9D%E3%81%9F%E3%81%A1%E3%81%A4%E3%81%A6%E3%81%A8%E3%81%AA%
I/flutter (19532):     response.statusCode: 200
I/flutter (19532):     response.data: {total_count: 0, incomplete_results: false, items: []}
I/flutter (19532):     response.headers: - omission -
I/flutter (19532): }
I/flutter (19532): SearchRepoInfoModel - total count=0, items=0, query="01234" in:readme "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもアイウエオカin:description "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもアイウエオカキクケコサシスセソタチツテトナニヌネノカキクケコサシスセソタチツテトナニヌサシスセソタチツテトナニヌネノ" in:topics, perPage=20, currentPage=1
I/flutter (19532): searchRepoByInQuery totalCount=0, loadedCount=0
I/flutter (19532): debug - ResultsPage - build
```

- マルチバイト文字やエスケープ文字を区別せず、256文字以内であれば 422 エラーにならなかった。
  - 数字の代わりにエスケーピングされる @ を使っても最大文字数は変わらない。
```
I/flutter (19532): searchRepositories - paramString[256]="@@@@@" "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもアイウエオカキクケコサシスセソタチツねのはひふへほまみむめもアイウエオカキクケコサシスセソタチツテトナニヌネノカキクケコサシスセソタチツテトナニヌネノ" "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもアイウエオカキクケコサシスセソタチツテトナニヌネノカキクケコサシスセソタチツテトナニヌネノ"
I/flutter (19532): [GET] request - data={q: "@@@@@" in:readme "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもアイウエオカキクケコサシスセソタチツテトしすせそたちつてとなにぬねのはひふへほまみむめもアイウエオカキクケコサシスセソタチツテトナニヌネノカキクケコサシスセソタチツテトナニヌネノ" in:name "あいうえおかきくけこさし sort: updated, order: desc, per_page: 20, page: 1}
I/flutter (19532): [GET] response {
I/flutter (19532):     request.uri: https://api.github.com/search/repositories?q=%22%40%40%40%40%40%22+in%3Areadme+%22%E3%81%82%E3%81%84%E3%81%86%E3%81%88%E3%81%8A%E3%81%8B%E3%81%8D%E3%81%8F%E3%81%91%E3%81%93%E3%81%95%E3%81%97%E3%81%99%E3%81%9B%E3%81%9D%E3%81%9F%E3%81%A1%E3%81%A4%E3%81%A6%E3%81%A8%E3%81%AA%E3%81%AB%E3%81%AC%E3%81%AD%E3%81%AE%E3%81%AF%E3%81%B2%E3%81%B5%E3%81%B8%E3%81%BB%E3%81%BE%E3%81%BF%E3%82%80%E3%82%81%E3%82%82%E3%82%A2%E3%82%A4%E3%82%A6%E3%82%A8%E3%82%AA%E3%82%AB%E3%82%AD%E3%82%AF%E3%82%B1%E3%82%B3%E3%82%B5%E3%82%B7%E3%82%B9%E3%82%BB%E3%82%BD%E3%82%BF%E3%83%81%E3%83%84%E3%83%86%E3%83%88%E3%83%8A%E3%83%8B%E3%83%8C%E3%83%8D%E3%83%8E%E3%82%AB%E3%82%AD%E3%82%AF%E3%82%B1%E3%82%B3%E3%82%B5%E3%82%B7%E3%82%B9%E3%82%BB%E3%82%BD%E3%82%BF%E3%83%81%E3%83%84%E3%83%86%E3%83%88%E3%83%8A%E3%83%8B%E3%83%8C%E3%83%8D%E3%83%8E%22+in%3Adescription+%22%E3%81%82%E3%81%84%E3%81%86%E3%81%88%E3%81%8A%E3%81%8B%E3%81%8D%E3%81%8F%E3%81%91%E3%81%93%E3%81%95%E3%81%97%E3%81%99%E3%81%9B%E3%81%9D%E3%81%9F%E3%81%A1%E3%81%A4%E3%81%A6%E3%81%A8
I/flutter (19532):     response.statusCode: 200
I/flutter (19532):     response.data: {total_count: 0, incomplete_results: false, items: []}
I/flutter (19532):     response.headers: - omission -
I/flutter (19532): }
I/flutter (19532): SearchRepoInfoModel - total count=0, items=0, query="@@@@@" in:readme "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもアイウエオカin:description "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもアイウエオカキクケコサシスセソタチツテトナニヌネノカキクケコサシスセソタチツテトナニヌサシスセソタチツテトナニヌネノ" in:topics, perPage=20, currentPage=1
I/flutter (19532): searchRepoByInQuery totalCount=0, loadedCount=0
I/flutter (19532): debug - ResultsPage - build
```
